### PR TITLE
Feat: Add Beacon.family

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -102,6 +102,7 @@ class FutureCounter extends StatelessWidget {
 -   [Beacon.derived](#beaconderived): Compute values reactively based on other beacons.
 -   [Beacon.derivedFuture](#beaconderivedfuture): Asynchronously compute values with state tracking.
 -   [Beacon.list](#beaconlist): Manage lists reactively.
+-   [Beacon.family](#beaconfamily): Create and manage a family of related beacons.
 
 [Pitfalls](#pitfalls)
 
@@ -490,6 +491,36 @@ print(bufferBeacon.buffer); // Outputs: [5, 5]
 count.value = 10;
 
 print(bufferBeacon.buffer); // Outputs: [5, 5, 10, 10]
+```
+
+### Beacon.family:
+
+Creates and manages a family of related `Beacon`s based on a single creation function.
+
+This class provides a convenient way to handle related
+beacons that share the same creation logic but have different arguments.
+
+### Type Parameters:
+
+-   `T`: The type of the value emitted by the signals in the family.
+-   `Arg`: The type of the argument used to identify individual beacons within the family.
+-   `BeaconType`: The type of the beacon in the family.
+
+If `cache` is `true`, created signals are cached. Default is `false`.
+
+A common use-case is dependency injection.
+
+Example:
+
+```dart
+final apiClientFamily = Beacon.family(
+ (String baseUrl) {
+   return Beacon.readable(ApiClient(baseUrl));
+ },
+);
+
+final githubApiClient = apiClientFamily('https://api.github.com');
+final twitterApiClient = apiClientFamily('https://api.twitter.com');
 ```
 
 ## Pitfalls

--- a/state_beacon/CHANGELOG.md
+++ b/state_beacon/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.14.2
+
+-   Add Beacon.family
+-   Add myBeacon.onDispose to listen to when a beacon is disposed
+-   Add `onCancel` to `toSteam()` extension method
+
 ## 0.14.1
 
 -   internal improvements

--- a/state_beacon/README.md
+++ b/state_beacon/README.md
@@ -102,6 +102,7 @@ class FutureCounter extends StatelessWidget {
 -   [Beacon.derived](#beaconderived): Compute values reactively based on other beacons.
 -   [Beacon.derivedFuture](#beaconderivedfuture): Asynchronously compute values with state tracking.
 -   [Beacon.list](#beaconlist): Manage lists reactively.
+-   [Beacon.family](#beaconfamily): Create and manage a family of related beacons.
 
 [Pitfalls](#pitfalls)
 
@@ -490,6 +491,36 @@ print(bufferBeacon.buffer); // Outputs: [5, 5]
 count.value = 10;
 
 print(bufferBeacon.buffer); // Outputs: [5, 5, 10, 10]
+```
+
+### Beacon.family:
+
+Creates and manages a family of related `Beacon`s based on a single creation function.
+
+This class provides a convenient way to handle related
+beacons that share the same creation logic but have different arguments.
+
+### Type Parameters:
+
+-   `T`: The type of the value emitted by the signals in the family.
+-   `Arg`: The type of the argument used to identify individual beacons within the family.
+-   `BeaconType`: The type of the beacon in the family.
+
+If `cache` is `true`, created signals are cached. Default is `false`.
+
+A common use-case is dependency injection.
+
+Example:
+
+```dart
+final apiClientFamily = Beacon.family(
+ (String baseUrl) {
+   return Beacon.readable(ApiClient(baseUrl));
+ },
+);
+
+final githubApiClient = apiClientFamily('https://api.github.com');
+final twitterApiClient = apiClientFamily('https://api.twitter.com');
 ```
 
 ## Pitfalls

--- a/state_beacon/lib/src/base_beacon.dart
+++ b/state_beacon/lib/src/base_beacon.dart
@@ -140,6 +140,10 @@ abstract class BaseBeacon<T> implements ValueListenable<T> {
     if (!_isEmpty) _value = _initialValue;
     _previousValue = null;
     _isDisposed = true;
+    for (final callback in _disposeCallbacks) {
+      callback();
+    }
+    _disposeCallbacks.clear();
   }
 
   @override
@@ -269,5 +273,16 @@ abstract class BaseBeacon<T> implements ValueListenable<T> {
       },
       detach: context,
     );
+  }
+
+  final List<VoidCallback> _disposeCallbacks = [];
+
+  /// Registers a callback to be called when the beacon is disposed.
+  void onDispose(VoidCallback callback) {
+    if (isDisposed) {
+      callback();
+    } else {
+      _disposeCallbacks.add(callback);
+    }
   }
 }

--- a/state_beacon/lib/src/base_beacon.dart
+++ b/state_beacon/lib/src/base_beacon.dart
@@ -184,38 +184,10 @@ abstract class BaseBeacon<T> implements ValueListenable<T> {
   T watch(BuildContext context) {
     final key = context.hashCode;
 
-    if (_subscribers.contains(key)) {
-      return _value;
-    }
-
-    _subscribers.add(key);
-
-    final elementRef = WeakReference(context as Element);
-    late VoidCallback unsub;
-
-    void rebuildWidget(T value) {
-      if (elementRef.target?.mounted ?? false) {
-        elementRef.target!.markNeedsBuild();
-      } else {
-        unsub();
-        _subscribers.remove(key);
-      }
-    }
-
-    unsub = subscribe(rebuildWidget);
-
-    // clean up if the widget is disposed
-    // and value is never modified again
-    _finalizer.attach(
+    return _watchOrObserve(
+      key,
       context,
-      () {
-        _subscribers.remove(key);
-        unsub();
-      },
-      detach: context,
     );
-
-    return _value;
   }
 
   /// Observes the state of a beacon and triggers a callback with the current state.
@@ -245,26 +217,46 @@ abstract class BaseBeacon<T> implements ValueListenable<T> {
       'isObserving', // 1 widget should only observe once
     );
 
+    _watchOrObserve(
+      key,
+      context,
+      callback: callback,
+    );
+  }
+
+  T _watchOrObserve(
+    int key,
+    BuildContext context, {
+    ObserverCallback<T>? callback,
+  }) {
+    final isObserving = callback != null;
+
     if (_subscribers.contains(key)) {
-      return;
+      return _value;
     }
+
+    _subscribers.add(key);
 
     final elementRef = WeakReference(context as Element);
     late VoidCallback unsub;
 
-    void notifyWidget(T value) {
+    void rebuildWidget(T value) {
       if (elementRef.target?.mounted ?? false) {
-        callback(previousValue as T, value);
+        if (isObserving) {
+          callback(previousValue as T, value);
+        } else {
+          elementRef.target!.markNeedsBuild();
+        }
       } else {
         unsub();
         _subscribers.remove(key);
       }
     }
 
-    unsub = subscribe(notifyWidget);
+    unsub = subscribe(rebuildWidget);
 
-    _subscribers.add(key);
-
+    // clean up if the widget is disposed
+    // and value is never modified again
     _finalizer.attach(
       context,
       () {
@@ -273,16 +265,16 @@ abstract class BaseBeacon<T> implements ValueListenable<T> {
       },
       detach: context,
     );
+
+    return _value;
   }
 
   final List<VoidCallback> _disposeCallbacks = [];
 
   /// Registers a callback to be called when the beacon is disposed.
   void onDispose(VoidCallback callback) {
-    if (isDisposed) {
-      callback();
-    } else {
-      _disposeCallbacks.add(callback);
-    }
+    if (isDisposed) return;
+
+    _disposeCallbacks.add(callback);
   }
 }

--- a/state_beacon/lib/src/beacons/family.dart
+++ b/state_beacon/lib/src/beacons/family.dart
@@ -1,0 +1,24 @@
+import 'package:state_beacon/src/base_beacon.dart';
+
+class BeaconFamily<Arg, BeaconType extends BaseBeacon> {
+  final bool shouldCache;
+  final Map<Arg, BeaconType> _cache = {};
+  final BeaconType Function(Arg) _create;
+
+  BeaconFamily(this._create, {this.shouldCache = false});
+
+  /// Retrieves a `Beacon` based on the given argument.
+  /// If caching is enabled and a beacon for the provided argument exists in the cache, it is returned.
+  /// Otherwise, a new beacon is created using the `create` function.
+  BeaconType call(Arg arg) {
+    if (shouldCache) {
+      return _cache[arg] ??= _create(arg);
+    }
+    return _create(arg);
+  }
+
+  /// Clears the cache of beacon if caching is enabled.
+  void clear() {
+    _cache.clear();
+  }
+}

--- a/state_beacon/lib/src/extensions/readable.dart
+++ b/state_beacon/lib/src/extensions/readable.dart
@@ -2,17 +2,24 @@ part of 'extensions.dart';
 
 extension ReadableBeaconUtils<T> on ReadableBeacon<T> {
   /// Converts a [ReadableBeacon] to [Stream]
-  Stream<T> toStream() {
+  Stream<T> toStream({
+    FutureOr<void> Function()? onCancel,
+  }) {
     final controller = StreamController<T>();
 
     controller.add(value);
 
     final unsub = subscribe((v) => controller.add(v));
 
-    controller.onCancel = () {
+    void cancel() {
       unsub();
       controller.close();
-    };
+      onCancel?.call();
+    }
+
+    controller.onCancel = cancel;
+
+    onDispose(cancel);
 
     return controller.stream;
   }

--- a/state_beacon/lib/src/state_beacon.dart
+++ b/state_beacon/lib/src/state_beacon.dart
@@ -1,5 +1,6 @@
 // ignore_for_file: invalid_use_of_protected_member
 
+import 'package:state_beacon/src/beacons/family.dart';
 import 'package:state_beacon/src/untracked.dart';
 
 import 'async_value.dart';
@@ -498,5 +499,37 @@ abstract class Beacon {
   /// ```
   static void untracked(VoidCallback fn) {
     doUntracked(fn);
+  }
+
+  /// Creates and manages a family of related `Beacon`s based on a single creation function.
+  ///
+  /// This class provides a convenient way to handle related
+  /// beacons that share the same creation logic but have different arguments.
+  ///
+  /// ### Type Parameters:
+  ///
+  /// * `T`: The type of the value emitted by the signals in the family.
+  /// * `Arg`: The type of the argument used to identify individual beacons within the family.
+  /// * `BeaconType`: The type of the beacon in the family.
+  ///
+  /// If `cache` is `true`, created signals are cached. Default is `false`.
+  ///
+  /// Example:
+  /// ```dart
+  ///final apiClientFamily = Beacon.family(
+  ///  (String baseUrl) {
+  ///    return Beacon.readable(ApiClient(baseUrl));
+  ///  },
+  ///);
+  ///
+  /// final githubApiClient = apiClientFamily('https://api.github.com');
+  /// final twitterApiClient = apiClientFamily('https://api.twitter.com');
+  /// ```
+  static BeaconFamily<Arg, BeaconType>
+      family<T, Arg, BeaconType extends BaseBeacon<T>>(
+    BeaconType Function(Arg) create, {
+    bool cache = false,
+  }) {
+    return BeaconFamily<Arg, BeaconType>(create, shouldCache: cache);
   }
 }

--- a/state_beacon/pubspec.yaml
+++ b/state_beacon/pubspec.yaml
@@ -1,6 +1,6 @@
 name: state_beacon
 description: A reactive primitive and simple state managerment solution for dart and flutter
-version: 0.14.1
+version: 0.14.2
 repository: https://github.com/jinyus/dart_beacon
 
 environment:

--- a/state_beacon/test/extension_test.dart
+++ b/state_beacon/test/extension_test.dart
@@ -30,8 +30,8 @@ void main() {
 
   test('should convert a beacon to a stream', () async {
     var beacon = Beacon.writable(0);
-
-    var stream = beacon.toStream();
+    var cancelled = false;
+    var stream = beacon.toStream(onCancel: () => cancelled = true);
 
     expect(stream, isA<Stream<int>>());
 
@@ -50,6 +50,12 @@ void main() {
     await Future.delayed(k10ms);
 
     expect(called, 3);
+
+    beacon.dispose();
+
+    await Future.delayed(k10ms);
+
+    expect(cancelled, true);
   });
 
   test('should toggle bool beacon', () {

--- a/state_beacon/test/family_test.dart
+++ b/state_beacon/test/family_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:state_beacon/state_beacon.dart';
+
+void main() {
+  test('should create a new beacon', () {
+    var family = Beacon.family((int arg) => Beacon.writable(arg.toString()));
+    var beacon = family(1);
+
+    expect(beacon.value, '1');
+  });
+
+  // Test for caching behavior
+  test('should cache created beacons', () {
+    var family = Beacon.family(
+      (int arg) => Beacon.writable(arg.toString()),
+      cache: true,
+    );
+    var beacon1 = family(1);
+    var beacon2 = family(1);
+
+    // Both beacons should be the same instance
+    expect(identical(beacon1, beacon2), isTrue);
+  });
+
+  test('should not cache Beacons if cache is false', () {
+    var family = Beacon.family(
+      (int arg) => Beacon.writable(arg.toString()),
+      cache: false,
+    );
+    var beacon1 = family(1);
+    var beacon2 = family(1);
+
+    // Beacons should not be the same instance
+    expect(identical(beacon1, beacon2), isFalse);
+  });
+
+  test('should clear the cache', () {
+    var family = Beacon.family(
+      (int arg) => Beacon.writable(arg.toString()),
+      cache: true,
+    );
+
+    var beacon1 = family(1);
+
+    family.clear();
+    var beacon2 = family(1);
+
+    // Beacons should not be the same instance after cache is cleared
+    expect(identical(beacon1, beacon2), isFalse);
+  });
+}


### PR DESCRIPTION
Credit to @LeeMatthewHiggins 

### Beacon.family:

Creates and manages a family of related `Beacon`s based on a single creation function.

```dart
final apiClientFamily = Beacon.family(
 (String baseUrl) {
   return Beacon.readable(ApiClient(baseUrl));
 },
);

final githubApiClient = apiClientFamily('https://api.github.com');
final twitterApiClient = apiClientFamily('https://api.twitter.com');
```