### PR TITLE
Make untracked local

### DIFF
--- a/state_beacon/CHANGELOG.md
+++ b/state_beacon/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.0
+
+-   Beacon.untracked() now only hide the update/access from encompassing effects.
+
 ## 0.14.6
 
 -   Add `tryCatch` method to AsyncValue class that executes a future and returns an AsyncData or AsyncError

--- a/state_beacon/lib/src/listeners.dart
+++ b/state_beacon/lib/src/listeners.dart
@@ -16,6 +16,11 @@ class Listeners {
     return added;
   }
 
+  void addAll(Iterable<EffectClosure> items) {
+    _set.addAll(items);
+    _list.addAll(items);
+  }
+
   bool remove(EffectClosure item) {
     bool removed = _set.remove(item);
     if (removed) {

--- a/state_beacon/lib/src/untracked.dart
+++ b/state_beacon/lib/src/untracked.dart
@@ -1,9 +1,27 @@
+import 'package:state_beacon/src/common.dart';
+
 var _untrackedStack = 0;
 
 bool isRunningUntracked() => _untrackedStack > 0;
 
+// when running untracked, we will remove the current effects from the beacon's listeners
+// so they won't be notified when the value is accessed;
+// therefore, we need to re-add them after the untracked block is done
+VoidCallback? reAddListeners;
+
 void doUntracked(void Function() fn) {
+  if (isRunningUntracked()) {
+    fn();
+    return;
+  }
+
   _untrackedStack++;
-  fn();
-  _untrackedStack--;
+
+  try {
+    fn();
+  } finally {
+    _untrackedStack--;
+    reAddListeners?.call();
+    reAddListeners = null;
+  }
 }

--- a/state_beacon/pubspec.yaml
+++ b/state_beacon/pubspec.yaml
@@ -1,6 +1,6 @@
 name: state_beacon
 description: A reactive primitive and simple state managerment solution for dart and flutter
-version: 0.14.6
+version: 0.15.0
 repository: https://github.com/jinyus/dart_beacon
 
 environment:

--- a/state_beacon/test/untracked_test.dart
+++ b/state_beacon/test/untracked_test.dart
@@ -5,20 +5,42 @@ void main() {
   test('should not send notification when doing untracked updates', () {
     final age = Beacon.writable<int>(10);
     var callCount = 0;
-    age.subscribe((_) => callCount++);
 
     Beacon.createEffect(() {
       age.value;
+      callCount++;
       Beacon.untracked(() {
         age.value = 15;
       });
     });
 
-    expect(callCount, equals(0));
+    expect(callCount, equals(1));
     expect(age.value, 15);
 
     age.value = 20;
+    expect(callCount, equals(2));
+  });
+
+  test('should not send notification when doing nested untracked updates', () {
+    final age = Beacon.writable<int>(10);
+    var callCount = 0;
+
+    Beacon.createEffect(() {
+      age.value;
+      callCount++;
+      Beacon.untracked(() {
+        age.value = 15;
+        Beacon.untracked(() {
+          age.value = 20;
+        });
+      });
+    });
+
     expect(callCount, equals(1));
+    expect(age.value, 20);
+
+    age.value = 25;
+    expect(callCount, equals(2));
   });
 
   test('should not send notification when doing untracked access', () {
@@ -29,10 +51,10 @@ void main() {
 
     Beacon.createEffect(() {
       age.value;
+      callCount++;
       Beacon.untracked(() {
         name.value;
       });
-      callCount++;
     });
 
     expect(callCount, equals(1));


### PR DESCRIPTION
## Description

Previously, `Beacon.untracked()` would hide the update/access from all listeners. This PR changes its behavior so it only hides from the current effects.

## Type of Change

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
