### PR TITLE
remove family beacons from cache when they are disposed

### DIFF
--- a/state_beacon/lib/src/beacons/family.dart
+++ b/state_beacon/lib/src/beacons/family.dart
@@ -17,7 +17,10 @@ class BeaconFamily<Arg, BeaconType extends BaseBeacon<dynamic>> {
   BeaconType call(Arg arg) {
     if (!shouldCache) return _create(arg);
 
-    return _cache[arg] ??= _create(arg);
+    return _cache[arg] ??= _create(arg)
+      ..onDispose(() {
+        _cache.remove(arg);
+      });
   }
 
   /// Clears the cache of beacon if caching is enabled.
@@ -25,9 +28,10 @@ class BeaconFamily<Arg, BeaconType extends BaseBeacon<dynamic>> {
   void clear() {
     if (!shouldCache) return;
 
-    for (final beacon in _cache.values) {
+    for (final beacon in _cache.values.toList()) {
       beacon.dispose();
     }
+
     _cache.clear();
   }
 }

--- a/state_beacon/test/src/beacons/family_test.dart
+++ b/state_beacon/test/src/beacons/family_test.dart
@@ -70,6 +70,20 @@ void main() {
     expect(identical(beacon1, beacon2), isTrue);
   });
 
+  test('should remove from cache when disposed', () {
+    final family = Beacon.family(
+      (int arg) => Beacon.writable(arg.toString()),
+      cache: true,
+    );
+    final beacon1 = family(1);
+
+    beacon1.dispose();
+
+    final beacon2 = family(1);
+
+    expect(identical(beacon1, beacon2), isFalse);
+  });
+
   test('should not cache Beacons if cache is false', () {
     final family = Beacon.family(
       (int arg) => Beacon.writable(arg.toString()),


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Status

**READY/IN DEVELOPMENT/HOLD**

## Description

memleak - family beacons were kept in cache after they were disposed.

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
