### PR TITLE
Add disposeTogether parameter for wrapping

### DIFF
--- a/state_beacon/lib/src/base_beacon.dart
+++ b/state_beacon/lib/src/base_beacon.dart
@@ -303,11 +303,11 @@ abstract class BaseBeacon<T> implements ValueListenable<T> {
     _widgetSubscribers.clear();
     if (!_isEmpty) _value = _initialValue;
     _previousValue = null;
-    _isDisposed = true;
     for (final callback in _disposeCallbacks) {
       callback();
     }
     _disposeCallbacks.clear();
+    _isDisposed = true;
     BeaconObserver.instance?.onDispose(this);
   }
 

--- a/state_beacon/lib/src/beacons/buffered.dart
+++ b/state_beacon/lib/src/beacons/buffered.dart
@@ -33,6 +33,7 @@ abstract class BufferedBaseBeacon<T> extends ReadableBeacon<List<T>>
     ReadableBeacon<U> target, {
     void Function(BufferedBaseBeacon<T> p1, U p2)? then,
     bool startNow = true,
+    bool disposeTogether = false,
   }) {
     if (_wrapped.containsKey(target.hashCode)) return this;
 
@@ -47,6 +48,22 @@ abstract class BufferedBaseBeacon<T> extends ReadableBeacon<List<T>>
     }, startNow: startNow);
 
     _wrapped[target.hashCode] = unsub;
+
+    if (disposeTogether) {
+      bool isDisposing = false;
+
+      target.onDispose(() {
+        if (isDisposing) return;
+        isDisposing = true;
+        dispose();
+      });
+
+      this.onDispose(() {
+        if (isDisposing) return;
+        isDisposing = true;
+        target.dispose();
+      });
+    }
 
     return this;
   }

--- a/state_beacon/lib/src/beacons/writable.dart
+++ b/state_beacon/lib/src/beacons/writable.dart
@@ -26,6 +26,7 @@ class WritableBeacon<T> extends ReadableBeacon<T>
     ReadableBeacon<U> target, {
     void Function(WritableBeacon<T> beacon, U newValue)? then,
     bool startNow = true,
+    bool disposeTogether = false,
   }) {
     if (_wrapped.containsKey(target.hashCode)) return this;
 
@@ -43,6 +44,22 @@ class WritableBeacon<T> extends ReadableBeacon<T>
     );
 
     _wrapped[target.hashCode] = unsub;
+
+    if (disposeTogether) {
+      bool isDisposing = false;
+
+      target.onDispose(() {
+        if (isDisposing) return;
+        isDisposing = true;
+        dispose();
+      });
+
+      this.onDispose(() {
+        if (isDisposing) return;
+        isDisposing = true;
+        target.dispose();
+      });
+    }
 
     return this;
   }

--- a/state_beacon/lib/src/extensions/readable.dart
+++ b/state_beacon/lib/src/extensions/readable.dart
@@ -82,7 +82,10 @@ extension ReadableBeaconUtils<T> on ReadableBeacon<T> {
     return Beacon.bufferedCount(
       count,
       debugLabel: debugLabel,
-    )..wrap(this);
+    )..wrap(
+        this,
+        disposeTogether: true,
+      );
   }
 
   /// Returns a [BufferedTimeBeacon] that wraps this Beacon.
@@ -94,7 +97,10 @@ extension ReadableBeaconUtils<T> on ReadableBeacon<T> {
     return Beacon.bufferedTime(
       duration: duration,
       debugLabel: debugLabel,
-    )..wrap(this);
+    )..wrap(
+        this,
+        disposeTogether: true,
+      );
   }
 
   /// Returns a [DebouncedBeacon] that wraps this Beacon.
@@ -108,7 +114,10 @@ extension ReadableBeaconUtils<T> on ReadableBeacon<T> {
       initialValue,
       duration: duration,
       debugLabel: debugLabel,
-    )..wrap(this);
+    )..wrap(
+        this,
+        disposeTogether: true,
+      );
   }
 
   /// Returns a [ThrottledBeacon] that wraps this Beacon.
@@ -124,7 +133,10 @@ extension ReadableBeaconUtils<T> on ReadableBeacon<T> {
       duration: duration,
       dropBlocked: dropBlocked,
       debugLabel: debugLabel,
-    )..wrap(this);
+    )..wrap(
+        this,
+        disposeTogether: true,
+      );
   }
 
   /// Returns a [FilteredBeacon] that wraps this Beacon.
@@ -132,7 +144,12 @@ extension ReadableBeaconUtils<T> on ReadableBeacon<T> {
   FilteredBeacon<T> filter(
     T initialValue, {
     bool Function(T?, T)? filter,
+    String? debugLabel,
   }) {
-    return Beacon.filtered(initialValue, filter: filter)..wrap(this);
+    return Beacon.filtered(initialValue, filter: filter)
+      ..wrap(
+        this,
+        disposeTogether: true,
+      );
   }
 }

--- a/state_beacon/lib/src/interfaces.dart
+++ b/state_beacon/lib/src/interfaces.dart
@@ -9,6 +9,9 @@ abstract class BeaconConsumer<S> {
   /// NB: If no `then` function is provided, the value type of the target must be
   /// the same as the wrapper beacon.
   ///
+  /// If the `disposeTogether` parameter is set to `true` (default), the wrapper beacon
+  /// will be disposed when the target beacon is disposed and vice versa.
+  ///
   /// Example:
   /// ```dart
   /// var bufferBeacon = Beacon.bufferedCount<int>(10);
@@ -31,6 +34,7 @@ abstract class BeaconConsumer<S> {
     ReadableBeacon<U> target, {
     void Function(S, U)? then,
     bool startNow = true,
+    bool disposeTogether = false,
   });
 
   void clearWrapped();

--- a/state_beacon/lib/src/observer.dart
+++ b/state_beacon/lib/src/observer.dart
@@ -30,10 +30,10 @@ class LoggingObserver implements BeaconObserver {
 
     debugPrint(
       '''
-Beacon updated:
-  label: ${beacon.debugLabel}
+
+"${beacon.debugLabel}" was updated:
   old: ${beacon.previousValue}
-  new: ${beacon.peek()}\n''',
+  new: ${beacon.peek()}\n\n\n''',
     );
   }
 
@@ -41,7 +41,7 @@ Beacon updated:
   void onDispose(BaseBeacon<dynamic> beacon) {
     if (!shouldContinue(beacon.debugLabel)) return;
 
-    debugPrint('Beacon disposed: ${beacon.debugLabel}\n');
+    debugPrint('\n"${beacon.debugLabel}" was disposed\n\n');
   }
 
   @override
@@ -49,7 +49,7 @@ Beacon updated:
     if (!shouldContinue(beacon.debugLabel)) return;
 
     final lazyLabel = lazy ? 'Lazy' : '';
-    debugPrint('${lazyLabel}Beacon created: ${beacon.debugLabel}\n');
+    debugPrint('\n${lazyLabel}Beacon created: ${beacon.debugLabel}\n\n');
   }
 
   bool shouldContinue(String label) {
@@ -63,9 +63,8 @@ Beacon updated:
 
     debugPrint(
       '''
-Effect watching beacon:
-  effect: $effectLabel
-  beacon: ${beacon.debugLabel}\n''',
+
+$effectLabel is watching ${beacon.debugLabel}\n\n''',
     );
   }
 
@@ -75,9 +74,8 @@ Effect watching beacon:
 
     debugPrint(
       '''
-Effect stopped watching beacon:
-  effect: $effectLabel
-  beacon: ${beacon.debugLabel}\n''',
+
+$effectLabel stopped watching ${beacon.debugLabel}\n\n''',
     );
   }
   // coverage:ignore-end

--- a/state_beacon/test/src/wrapping_test.dart
+++ b/state_beacon/test/src/wrapping_test.dart
@@ -139,4 +139,76 @@ void main() {
     expect(streamCalled, equals(15));
     expect(throttledCalled, equals(1));
   });
+
+  test('should dispose together when wrapper is disposed', () {
+    // BeaconObserver.instance = LoggingObserver();
+    var count = Beacon.readable<int>(10, debugLabel: 'readable');
+    var doubledCount = Beacon.derived<int>(
+      () => count.value * 2,
+      debugLabel: 'derived',
+    );
+
+    var wrapper = Beacon.writable<int>(0, debugLabel: 'wrapper');
+
+    wrapper.wrap(count, disposeTogether: true);
+    var buff = doubledCount.buffer(1).filter([]);
+
+    expect(wrapper.value, equals(10));
+
+    expect(doubledCount.listenersCount, 1);
+    expect(count.listenersCount, 2);
+
+    wrapper.dispose();
+
+    expect(doubledCount.listenersCount, 1);
+    expect(count.listenersCount, 0);
+    count.dispose();
+    buff.dispose();
+
+    expect(doubledCount.listenersCount, 0);
+  });
+
+  test('should dispose together when wrapped is disposed', () {
+    // BeaconObserver.instance = LoggingObserver();
+    var count = Beacon.readable<int>(10, debugLabel: 'readable');
+    var doubledCount = Beacon.derived<int>(
+      () => count.value * 2,
+      debugLabel: 'derived',
+    );
+
+    var wrapper = Beacon.writable<int>(0, debugLabel: 'wrapper');
+
+    wrapper.wrap(count, disposeTogether: true);
+    var _ = doubledCount.filter(0).buffer(1).wrap(
+          wrapper,
+          disposeTogether: true,
+        );
+
+    expect(wrapper.value, equals(10));
+
+    expect(doubledCount.listenersCount, 1);
+    expect(count.listenersCount, 2);
+
+    wrapper.dispose();
+
+    expect(doubledCount.listenersCount, 0);
+    expect(count.listenersCount, 0);
+  });
+
+  test('should dispose together when wrapped is disposed(2)', () {
+    // BeaconObserver.instance = LoggingObserver();
+    var count = Beacon.readable<int>(10, debugLabel: 'readable');
+
+    var wrapper = Beacon.writable<int>(0, debugLabel: 'wrapper');
+
+    wrapper.wrap(count, disposeTogether: true);
+
+    expect(wrapper.value, equals(10));
+
+    expect(count.listenersCount, 1);
+
+    count.dispose();
+
+    expect(count.listenersCount, 0);
+  });
 }


### PR DESCRIPTION
This pull request adds a new `disposeTogether` parameter to the `wrap` method in the `BeaconConsumer` class. When set to `true`, the wrapper beacon will be disposed when the target beacon is disposed, and vice versa. This allows for more convenient and consistent disposal of wrapped beacons.