### PR TITLE
[Perf] Cache the value notifier created by toValueNotifier() and toListenable()

### DIFF
--- a/packages/state_beacon/lib/src/extensions/extensions.dart
+++ b/packages/state_beacon/lib/src/extensions/extensions.dart
@@ -6,3 +6,43 @@ import 'package:state_beacon_core/state_beacon_core.dart';
 part 'readable.dart';
 part 'watch_observe.dart';
 part 'writable.dart';
+
+Map<int, ValueNotifierBeacon<dynamic>>? _vnCache;
+
+@visibleForTesting
+
+/// The number of value notifiers currently in use
+/// This is used for testing purposes only
+bool hasNotifier(BaseBeacon<dynamic> beacon) {
+  return _vnCache?.containsKey(beacon.hashCode) ?? false;
+}
+
+ValueNotifier<T> _toValueNotifier<T>(ReadableBeacon<T> beacon) {
+  _vnCache ??= {};
+
+  final key = beacon.hashCode;
+
+  final existing = _vnCache![key];
+
+  if (existing != null) {
+    return existing as ValueNotifierBeacon<T>;
+  }
+
+  final notifier = ValueNotifierBeacon(beacon.peek());
+
+  _vnCache![key] = notifier;
+
+  final unsub = beacon.subscribe(notifier.set);
+
+  notifier.addDisposeCallback(() {
+    unsub();
+    _vnCache!.remove(key);
+  });
+
+  beacon.onDispose(() {
+    notifier.dispose();
+    _vnCache!.remove(key);
+  });
+
+  return notifier;
+}

--- a/packages/state_beacon/lib/src/extensions/readable.dart
+++ b/packages/state_beacon/lib/src/extensions/readable.dart
@@ -4,14 +4,6 @@ part of 'extensions.dart';
 extension ReadableBeaconFlutterUtils<T> on ReadableBeacon<T> {
   /// Converts this to a [ValueListenable]
   ValueListenable<T> toListenable() {
-    final notifier = ValueNotifierBeacon(value);
-
-    final unsub = subscribe(notifier.set);
-
-    notifier.addDisposeCallback(unsub);
-
-    onDispose(notifier.dispose);
-
-    return notifier;
+    return _toValueNotifier(this);
   }
 }

--- a/packages/state_beacon/lib/src/extensions/writable.dart
+++ b/packages/state_beacon/lib/src/extensions/writable.dart
@@ -4,15 +4,9 @@ part of 'extensions.dart';
 extension WritableBeaconFlutterUtils<T> on WritableBeacon<T> {
   /// Converts this to a [ValueNotifier]
   ValueNotifier<T> toValueNotifier() {
-    final notifier = ValueNotifierBeacon(value);
+    final notifier = _toValueNotifier(this);
 
-    final unsub = subscribe(notifier.set);
-
-    notifier
-      ..addListener(() => value = notifier.value)
-      ..addDisposeCallback(unsub);
-
-    onDispose(notifier.dispose);
+    notifier.addListener(() => set(notifier.value));
 
     return notifier;
   }

--- a/packages/state_beacon/lib/state_beacon.dart
+++ b/packages/state_beacon/lib/state_beacon.dart
@@ -3,4 +3,4 @@ library;
 
 export 'package:state_beacon_core/state_beacon_core.dart';
 
-export 'src/extensions/extensions.dart';
+export 'src/extensions/extensions.dart' hide hasNotifier;

--- a/packages/state_beacon/test/src/extensions/readable_test.dart
+++ b/packages/state_beacon/test/src/extensions/readable_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:state_beacon/src/extensions/extensions.dart';
 import 'package:state_beacon/state_beacon.dart';
 
 void main() {
@@ -54,5 +55,43 @@ void main() {
       ..value = 3;
 
     expect(called, 2);
+  });
+
+  test('should return the same listener instance', () {
+    final beacon = Beacon.writable(0);
+
+    final valueNotifier = beacon.toListenable();
+    final valueNotifier2 = beacon.toListenable();
+    final valueNotifier3 = beacon.toListenable();
+
+    expect(valueNotifier, valueNotifier2);
+    expect(valueNotifier2, valueNotifier3);
+
+    expect(hasNotifier(beacon), isTrue);
+
+    beacon.dispose();
+
+    expect(hasNotifier(beacon), isFalse);
+  });
+
+  test('should remove notifier from cache when source is disposed.', () {
+    final age = Beacon.writable(50);
+    final name = Beacon.writable('bob');
+
+    age.toListenable();
+    name.toListenable();
+
+    expect(hasNotifier(age), isTrue);
+    expect(hasNotifier(name), isTrue);
+
+    age.dispose();
+
+    expect(hasNotifier(age), isFalse);
+    expect(hasNotifier(name), isTrue);
+
+    name.dispose();
+
+    expect(hasNotifier(age), isFalse);
+    expect(hasNotifier(name), isFalse);
   });
 }

--- a/packages/state_beacon/test/src/extensions/writable_test.dart
+++ b/packages/state_beacon/test/src/extensions/writable_test.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:state_beacon/src/extensions/extensions.dart';
 import 'package:state_beacon/state_beacon.dart';
 
 void main() {
@@ -53,5 +54,47 @@ void main() {
       ..value = 3;
 
     expect(called, 2);
+  });
+
+  test('should return the same notifier instance', () {
+    final beacon = Beacon.writable(0);
+
+    final valueNotifier = beacon.toValueNotifier();
+    final valueNotifier2 = beacon.toValueNotifier();
+    final valueNotifier3 = beacon.toValueNotifier();
+
+    expect(valueNotifier, valueNotifier2);
+    expect(valueNotifier2, valueNotifier3);
+
+    expect(hasNotifier(beacon), isTrue);
+
+    beacon.dispose();
+
+    expect(hasNotifier(beacon), isFalse);
+  });
+
+  test('should remove notifier from cache when notifier is disposed.', () {
+    final age = Beacon.writable(50);
+    final name = Beacon.writable('bob');
+
+    final aNotifier = age.toValueNotifier();
+    final nNotifier = name.toValueNotifier();
+
+    expect(hasNotifier(age), isTrue);
+    expect(hasNotifier(name), isTrue);
+    expect(age.listenersCount, 1);
+    expect(name.listenersCount, 1);
+
+    aNotifier.dispose();
+
+    expect(hasNotifier(age), isFalse);
+    expect(hasNotifier(name), isTrue);
+    expect(age.listenersCount, 0);
+
+    nNotifier.dispose();
+
+    expect(hasNotifier(age), isFalse);
+    expect(hasNotifier(name), isFalse);
+    expect(name.listenersCount, 0);
   });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Avoid creating new notifier instance when calling `beacon.toNotifier`. This can lead to memory leaks as it's most likely to be used in a build method.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [x] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
