### PR TITLE
[Refactor] add .stream getter and deprecate toStream() extension

### DIFF
--- a/packages/state_beacon_core/lib/src/beacons/list.dart
+++ b/packages/state_beacon_core/lib/src/beacons/list.dart
@@ -426,7 +426,7 @@ class ListBeacon<E> extends WritableBeacon<List<E>> {
 
   /// Clears the list
   @override
-  void reset() {
+  void reset({bool force = false}) {
     clear();
   }
 }

--- a/packages/state_beacon_core/lib/src/beacons/map.dart
+++ b/packages/state_beacon_core/lib/src/beacons/map.dart
@@ -146,7 +146,7 @@ class MapBeacon<K, V> extends WritableBeacon<Map<K, V>> {
 
   /// Clears the map
   @override
-  void reset() {
+  void reset({bool force = false}) {
     clear();
   }
 }

--- a/packages/state_beacon_core/lib/src/beacons/readable.dart
+++ b/packages/state_beacon_core/lib/src/beacons/readable.dart
@@ -4,4 +4,37 @@ part of '../base_beacon.dart';
 class ReadableBeacon<T> extends BaseBeacon<T> {
   /// @macro [ReadableBeacon]
   ReadableBeacon({super.initialValue, super.name});
+
+  StreamController<T>? _controller;
+  VoidCallback? _unsub;
+
+  /// Returns a broadcast [Stream] that emits the current value
+  /// and all subsequent updates to the value of this beacon.
+  Stream<T> get stream {
+    _controller ??= StreamController<T>.broadcast(
+      onListen: () {
+        if (!isEmpty) _controller!.add(peek());
+
+        // onListen is only called when sub count goes from 0 to 1.
+        // If sub count goes from 1 to 0, onCancel runs and sets _unsub to null.
+        // so _unsub will always be null here but checking doesn't hurt
+        _unsub ??= subscribe(_controller!.add);
+      },
+      onCancel: () {
+        _unsub?.call();
+        _unsub = null;
+      },
+    );
+
+    return _controller!.stream;
+  }
+
+  @override
+  void dispose() {
+    _unsub?.call();
+    _controller?.close();
+    _controller = null;
+    _unsub = null;
+    super.dispose();
+  }
 }

--- a/packages/state_beacon_core/lib/src/beacons/set.dart
+++ b/packages/state_beacon_core/lib/src/beacons/set.dart
@@ -114,7 +114,7 @@ class SetBeacon<E> extends WritableBeacon<Set<E>> {
 
   /// Clears the set
   @override
-  void reset() {
+  void reset({bool force = false}) {
     clear();
   }
 }

--- a/packages/state_beacon_core/lib/src/beacons/throttled.dart
+++ b/packages/state_beacon_core/lib/src/beacons/throttled.dart
@@ -68,9 +68,9 @@ class ThrottledBeacon<T> extends WritableBeacon<T> {
   }
 
   @override
-  void reset() {
+  void reset({bool force = false}) {
     _cleanUp();
-    super.reset();
+    super.reset(force: force);
   }
 
   @override

--- a/packages/state_beacon_core/lib/src/beacons/undo_redo.dart
+++ b/packages/state_beacon_core/lib/src/beacons/undo_redo.dart
@@ -70,9 +70,9 @@ class UndoRedoBeacon<T> extends WritableBeacon<T> {
   }
 
   @override
-  void reset() {
+  void reset({bool force = false}) {
     _history.clear();
     _currentHistoryIndex = -1;
-    super.reset();
+    super.reset(force: force);
   }
 }

--- a/packages/state_beacon_core/lib/src/beacons/writable.dart
+++ b/packages/state_beacon_core/lib/src/beacons/writable.dart
@@ -11,9 +11,9 @@ class WritableBeacon<T> extends ReadableBeacon<T> with BeaconConsumer<T, T> {
 
   /// Set the beacon to its initial value
   /// and notify all listeners
-  void reset() {
+  void reset({bool force = false}) {
     if (_isEmpty) return;
-    _setValue(_initialValue);
+    _setValue(_initialValue, force: force);
   }
 
   /// Sets the value of the beacon and allows a force notification

--- a/packages/state_beacon_core/lib/src/extensions/readable.dart
+++ b/packages/state_beacon_core/lib/src/extensions/readable.dart
@@ -4,11 +4,15 @@ part of 'extensions.dart';
 
 const _k10seconds = Duration(seconds: 10);
 
+// coverage:ignore-start
 final Map<int, Stream<dynamic>> _streamCache = {};
+// coverage:ignore-end
 
 extension ReadableBeaconUtils<T> on ReadableBeacon<T> {
+  // coverage:ignore-start
   /// Converts a [ReadableBeacon] to [Stream]
   /// The stream controller can only be canceled by calling [dispose]
+  @Deprecated('Use .stream instead')
   Stream<T> toStream({
     FutureOr<void> Function()? onCancel,
     @Deprecated('No longer needed') bool broadcast = false,
@@ -40,6 +44,7 @@ extension ReadableBeaconUtils<T> on ReadableBeacon<T> {
 
     return stream;
   }
+  // coverage:ignore-end
 
   /// Listens for the next value emitted by this Beacon and returns it as a Future.
   ///

--- a/packages/state_beacon_core/test/src/async_value_test.dart
+++ b/packages/state_beacon_core/test/src/async_value_test.dart
@@ -24,7 +24,7 @@ void main() {
   test('should set the beacon supplied', () async {
     final beacon = Beacon.writable<AsyncValue<int>>(AsyncData(0));
 
-    final beaconStream = beacon.toStream();
+    final beaconStream = beacon.stream;
 
     expect(
       beaconStream,
@@ -58,7 +58,7 @@ void main() {
   test('should set optimistic result while loading', () async {
     final beacon = Beacon.writable<AsyncValue<int>>(AsyncData(0));
 
-    final beaconStream = beacon.toStream();
+    final beaconStream = beacon.stream;
 
     expect(
       beaconStream,

--- a/packages/state_beacon_core/test/src/beacons/readable_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/readable_test.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:state_beacon_core/state_beacon_core.dart';
 import 'package:test/test.dart';
 
+import '../../common.dart';
+
 void main() {
   test('should set initial value', () {
     final beacon = Beacon.readable(10);
@@ -40,5 +42,71 @@ void main() {
     final result = await completer.future;
 
     expect(result, 1);
+  });
+
+  test('should return a stream', () async {
+    final a = Beacon.writable(1);
+
+    final stream = a.stream;
+
+    var called = 0;
+
+    final sub1 = stream.listen((v) => called++);
+    final sub2 = stream.listen((v) => called++);
+    final sub3 = stream.listen((v) => called++);
+
+    await Future<void>.delayed(k10ms);
+
+    // should only add on first listen
+    expect(called, 1);
+
+    a.increment();
+
+    await Future<void>.delayed(k1ms);
+
+    // all subs get notified
+    expect(called, 4);
+
+    await Future<void>.delayed(k1ms);
+
+    await sub1.cancel();
+
+    await sub2.cancel();
+
+    a.increment();
+
+    await Future<void>.delayed(k1ms);
+
+    expect(called, 5);
+
+    await sub3.cancel();
+
+    await Future<void>.delayed(k1ms);
+
+    a.increment();
+
+    await Future<void>.delayed(k1ms);
+
+    expect(called, 5);
+
+    final sub4 = stream.listen((v) => called++);
+
+    await Future<void>.delayed(k1ms);
+
+    expect(called, 6);
+
+    a.increment();
+
+    await Future<void>.delayed(k1ms);
+
+    expect(called, 7);
+
+    await sub4.cancel();
+
+    await Future<void>.delayed(k1ms);
+
+    a.increment();
+
+    expect(called, 7);
   });
 }

--- a/packages/state_beacon_core/test/src/beacons/stream_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/stream_test.dart
@@ -13,7 +13,7 @@ void main() {
     final myBeacon = Beacon.stream(myStream);
 
     expect(
-      myBeacon.toStream(),
+      myBeacon.stream,
       emitsInOrder([
         isA<AsyncLoading>(),
         isA<AsyncData<int>>(),
@@ -35,7 +35,7 @@ void main() {
     final myBeacon = Beacon.stream(errorStream());
 
     expect(
-      myBeacon.toStream(),
+      myBeacon.stream,
       emitsInOrder(
         [
           isA<AsyncLoading>(),

--- a/packages/state_beacon_core/test/src/creator/beacon_group_creator_test.dart
+++ b/packages/state_beacon_core/test/src/creator/beacon_group_creator_test.dart
@@ -26,8 +26,8 @@ void main() {
     final lazyTimestamp = group.lazyTimestamped<int>();
     final undoRedo = group.undoRedo<int>(0);
     final lazyUndoRedo = group.lazyUndoRedo<int>();
-    final stream = group.stream<int>(readable.toStream());
-    final streamRaw = group.streamRaw<int?>(readable.toStream());
+    final stream = group.stream<int>(readable.stream);
+    final streamRaw = group.streamRaw<int?>(readable.stream);
     final future = group.future<int>(() async => 1);
     final list = group.list<int>([0]);
     final hashSet = group.hashSet<int>({0});

--- a/packages/state_beacon_core/test/src/extensions/readable_test.dart
+++ b/packages/state_beacon_core/test/src/extensions/readable_test.dart
@@ -10,12 +10,7 @@ import '../../common.dart';
 void main() {
   test('should convert a beacon to a stream', () async {
     final beacon = Beacon.writable(0);
-    var onCanceledCalled = false;
-    final stream = beacon.toStream(
-      onCancel: () {
-        onCanceledCalled = true;
-      },
-    );
+    final stream = beacon.stream;
 
     expect(stream, isA<Stream<int>>());
 
@@ -32,17 +27,15 @@ void main() {
     beacon.value = 1;
     beacon.value = 2;
     beacon.dispose();
-
-    expect(onCanceledCalled, true);
   });
 
   test('should cache stream', () {
     final beacon = Beacon.writable(0);
 
-    final stream1 = beacon.toStream();
-    final stream2 = beacon.toStream();
+    final stream1 = beacon.stream;
+    final stream2 = beacon.stream;
 
-    expect(stream1, same(stream2));
+    expect(stream1.hashCode, stream2.hashCode);
   });
 
   test('next method completes with the setted value', () async {

--- a/packages/state_beacon_core/test/src/extensions/writable_test.dart
+++ b/packages/state_beacon_core/test/src/extensions/writable_test.dart
@@ -46,10 +46,8 @@ void main() {
   test('should set correct async state', () async {
     final beacon = Beacon.writable<AsyncValue<int>>(AsyncData(0));
 
-    final beaconStream = beacon.toStream();
-
     expect(
-      beaconStream,
+      beacon.stream,
       emitsInOrder(
         [
           AsyncData(0),


### PR DESCRIPTION
## Description

Replace the `.toStream()` extension method with a `.stream` getter. This is a bit more efficient since a map to cache the streams is no longer needed.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [x] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
