### PR TITLE
[Feat] Add beacon.ingest(anyStream)

### DIFF
--- a/packages/state_beacon_core/lib/src/beacons/buffered.dart
+++ b/packages/state_beacon_core/lib/src/beacons/buffered.dart
@@ -8,7 +8,7 @@ abstract class BufferedBaseBeacon<T> extends ReadableBeacon<List<T>>
 
   final List<T> _buffer = [];
 
-  final _currentBuffer = ListBeacon<T>([]);
+  late final _currentBuffer = ListBeacon<T>([], name: "$name's currentBuffer");
 
   /// The current buffer of values that have been added to this beacon.
   /// This can be listened to directly.

--- a/packages/state_beacon_core/lib/src/beacons/stream.dart
+++ b/packages/state_beacon_core/lib/src/beacons/stream.dart
@@ -1,4 +1,5 @@
-// ignore_for_file: avoid_types_on_closure_parameters
+// ignore: lines_longer_than_80_chars
+// ignore_for_file: avoid_types_on_closure_parameters, avoid_equals_and_hash_code_on_mutable_classes
 
 part of '../base_beacon.dart';
 
@@ -50,17 +51,27 @@ class RawStreamBeacon<T> extends ReadableBeacon<T> {
   /// @macro rawStream
   RawStreamBeacon(
     this._stream, {
+    this.isLazy = false,
     this.cancelOnError = false,
     this.onError,
     this.onDone,
     super.initialValue,
     super.name,
   }) : assert(
-          initialValue != null || null is T,
-          'provide an initialValue or change the type parameter "$T" to "$T?"',
+          initialValue != null || null is T || isLazy,
+          '''
+
+          Do one of the following:
+            1. provide an initialValue
+            2. change the type parameter "$T" to "$T?"
+            3. set isLazy to true (beacon must be set before it's read from)
+          ''',
         ) {
     _init();
   }
+
+  /// Whether the beacon has lazy initialization.
+  final bool isLazy;
 
   /// called when the stream emits an error
   final Function? onError;
@@ -96,5 +107,21 @@ class RawStreamBeacon<T> extends ReadableBeacon<T> {
     unsubscribe();
 
     super.dispose();
+  }
+
+  @override
+  int get hashCode =>
+      _stream.hashCode ^
+      cancelOnError.hashCode ^
+      onError.hashCode ^
+      onDone.hashCode ^
+      (isLazy ? 1 : initialValue.hashCode) ^
+      name.hashCode;
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is RawStreamBeacon && other.hashCode == hashCode;
   }
 }

--- a/packages/state_beacon_core/lib/src/creator/beacon_creator.dart
+++ b/packages/state_beacon_core/lib/src/creator/beacon_creator.dart
@@ -368,10 +368,14 @@ class _BeaconCreator {
   }
 
   /// Like `stream`, but it doesn't wrap the value in an `AsyncValue`.
-  /// If you dont supply an initial value, the type has to be nullable.
+  ///
+  /// One of the following must be `true` if an initial value isn't provided:
+  ///   1. The type is nullable
+  ///   2. `isLazy` is true (beacon must be set before it's read from)
   RawStreamBeacon<T> streamRaw<T>(
     Stream<T> stream, {
     bool cancelOnError = false,
+    bool isLazy = false,
     Function? onError,
     VoidCallback? onDone,
     T? initialValue,
@@ -383,6 +387,7 @@ class _BeaconCreator {
       onError: onError,
       onDone: onDone,
       initialValue: initialValue,
+      isLazy: isLazy,
       name: name ?? 'RawStreamBeacon<$T>',
     );
   }

--- a/packages/state_beacon_core/lib/src/creator/beacon_group_creator.dart
+++ b/packages/state_beacon_core/lib/src/creator/beacon_group_creator.dart
@@ -295,6 +295,7 @@ class BeaconGroup extends _BeaconCreator {
   RawStreamBeacon<T> streamRaw<T>(
     Stream<T> stream, {
     bool cancelOnError = false,
+    bool isLazy = false,
     Function? onError,
     VoidCallback? onDone,
     T? initialValue,
@@ -306,6 +307,7 @@ class BeaconGroup extends _BeaconCreator {
       onError: onError,
       onDone: onDone,
       initialValue: initialValue,
+      isLazy: isLazy,
       name: name,
     );
     _beacons.add(beacon);

--- a/packages/state_beacon_core/lib/src/extensions/iterable.dart
+++ b/packages/state_beacon_core/lib/src/extensions/iterable.dart
@@ -18,16 +18,20 @@ extension StreamUtils<T> on Stream<T> {
   /// Converts a stream to [RawStreamBeacon].
   RawStreamBeacon<T> toRawBeacon({
     bool cancelOnError = false,
+    bool isLazy = false,
     Function? onError,
     VoidCallback? onDone,
     T? initialValue,
+    String? name,
   }) {
     return RawStreamBeacon<T>(
       this,
       cancelOnError: cancelOnError,
+      isLazy: isLazy,
       onError: onError,
       onDone: onDone,
       initialValue: initialValue,
+      name: name,
     );
   }
 }

--- a/packages/state_beacon_core/lib/src/extensions/wrap.dart
+++ b/packages/state_beacon_core/lib/src/extensions/wrap.dart
@@ -77,4 +77,31 @@ extension WritableWrap<T, U> on BeaconConsumer<T, U> {
 
     return;
   }
+
+  /// Injest a `Stream` and add all values emitted from it to this beacon
+  ///
+  /// example:
+  /// ```dart
+  /// var beacon = Beacon.writable(0);
+  /// var myStream = Stream.fromIterable([1, 2, 3]);
+  ///
+  /// beacon.injest(myStream);
+  /// ```
+  void ingest(Stream<T> source, {void Function(T)? then}) {
+    final internalBeacon = RawStreamBeacon<T>(source, isLazy: true);
+
+    wrap(
+      internalBeacon,
+      then: then,
+      startNow: false,
+    );
+
+    internalBeacon.onDispose(() {
+      _wrapped.remove(internalBeacon.hashCode);
+      // don't dispose parent beacon because
+      // internal is disposed when the stream ends
+    });
+
+    onDispose(internalBeacon.dispose);
+  }
 }

--- a/packages/state_beacon_core/lib/src/mixins/beacon_consumer.dart
+++ b/packages/state_beacon_core/lib/src/mixins/beacon_consumer.dart
@@ -1,7 +1,11 @@
 part of '../base_beacon.dart';
 
+// the input type can differ from the output type
+// eg: in the case of buffered beacons,
+// the input type is int then the output type is List<int>
+
 /// A utility mixin for beacons that consume other beacons.
-mixin BeaconConsumer<T, U> on BaseBeacon<U> {
+mixin BeaconConsumer<InputT, OutputT> on BaseBeacon<OutputT> {
   final _wrapped = <int, VoidCallback>{};
 
   /// Disposes all currently wrapped beacons
@@ -14,7 +18,7 @@ mixin BeaconConsumer<T, U> on BaseBeacon<U> {
 
   /// Wrapper beacons can have different methods to set the value,
   /// so this is should be implemented by the wrapper.
-  void _onNewValueFromWrapped(T value);
+  void _onNewValueFromWrapped(InputT value);
 
   // String get _label;
 

--- a/packages/state_beacon_core/test/src/beacons/stream_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/stream_test.dart
@@ -83,4 +83,12 @@ void main() {
     expect(myBeacon.isDisposed, true);
     expect(buffered.isDisposed, true);
   });
+
+  test('should be equal to beacon with the same stream', () {
+    final myStream = Stream.periodic(k10ms, (i) => i + 1).asBroadcastStream();
+    final myBeacon = Beacon.streamRaw(myStream, initialValue: 0);
+    final myBeacon2 = Beacon.streamRaw(myStream, initialValue: 0);
+
+    expect(myBeacon, equals(myBeacon2));
+  });
 }

--- a/packages/state_beacon_core/test/src/wrapping_test.dart
+++ b/packages/state_beacon_core/test/src/wrapping_test.dart
@@ -1,4 +1,4 @@
-// ignore_for_file: cascade_invocations
+// ignore_for_file: cascade_invocations, unnecessary_statements
 
 import 'package:state_beacon_core/src/base_beacon.dart';
 import 'package:state_beacon_core/state_beacon_core.dart';
@@ -246,5 +246,33 @@ void main() {
     final wrapper = Beacon.writable<int>(0);
 
     expect(() => wrapper.wrap(count), throwsException);
+  });
+
+  test('should injest stream', () async {
+    final beacon = Beacon.writable<int>(0);
+    final myStream = Stream.fromIterable([1, 2, 3]);
+    final buffered = beacon.buffer(4);
+
+    beacon
+      ..ingest(myStream)
+      ..ingest(myStream, then: (v) => v * 2); // should have no effect
+
+    await expectLater(
+      buffered.next(),
+      completion([0, 1, 2, 3]),
+    );
+  });
+
+  test('should injest stream and transform values', () async {
+    final beacon = Beacon.writable<int>(0);
+    final myStream = Stream.fromIterable([1, 2, 3]);
+    final buffered = beacon.buffer(4);
+
+    beacon.ingest(myStream, then: (v) => beacon.value = v * 2);
+
+    await expectLater(
+      buffered.next(),
+      completion([0, 2, 4, 6]),
+    );
   });
 }


### PR DESCRIPTION
## Description

Any writable can now wrap a stream with the new `.injest() method`.

RawStreamBeacons can now be initialized lazily.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [x] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
