### PR TITLE
[Feat] Add Beacon.derivedStream along with tests

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -99,6 +99,7 @@ NB: Create the file if it doesn't exist.
 -   [Beacon.readable](#beaconreadable): Immutable beacon that only emit values, ideal for readonly data.
 -   [Beacon.effect](#beaconcreateeffect): React to changes in beacon values.
 -   [Beacon.derived](#beaconderived): Derive values from other beacons, keeping them reactively in sync.
+-   [Beacon.derivedStream](#beaconderivedstream): Specialized derived beacon that subscribes to the stream returned from its callback and updates its value based on the emitted values.
 -   [Beacon.derivedFuture](#beaconderivedfuture): Derive values from asynchronous operations, managing state during computation.
 -   [Beacon.future](#beaconfuture): Initialize beacons from futures.
     -   [overrideWith](#futurebeaconoverridewith): Replace the callback.
@@ -116,7 +117,7 @@ NB: Create the file if it doesn't exist.
     -   [Beacon.hashSet](#beaconhashset): Like Beacon.list, but for Sets.
     -   [Beacon.hashMap](#beaconhashmap): Like Beacon.list, but for Maps.
 -   [AsyncValue](#asyncvalue): A wrapper around a value that can be in one of four states: `idle`, `loading`, `data`, or `error`.
-    -   [unwrap](#asyncvalueunwrap): Casts this [AsyncValue] to [AsyncData] and return it's value.
+    -   [unwrap](#asyncvalueunwrap): Casts this [AsyncValue] to [AsyncData] and return its value.
     -   [lastData](#asyncvaluelastdata): Returns the latest valid data value or null.
     -   [tryCatch](#asyncvaluetrycatch): Execute a future and return [AsyncData] or [AsyncError].
     -   [optimistic updates](#asyncvaluetrycatch): Update the value optimistically when using tryCatch.
@@ -212,7 +213,7 @@ Creates a `DerivedBeacon` whose value is derived from a computation function.
 This beacon will recompute its value every time one of it's dependencies change.
 
 If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
-It will resume executing once a listener is added or it's value is accessed.
+It will resume executing once a listener is added or its value is accessed.
 
 If `supportConditional` is `false`(default: true), it will only look dependencies on its first run.
 This means once a beacon is added as a dependency, it will not be removed even if it's no longer used and no new dependencies will be added. This can be used a performance optimization.
@@ -230,6 +231,25 @@ age.value = 22;
 print(canDrink.value); // Outputs: true
 ```
 
+### Beacon.derivedStream:
+
+Specialized `DerivedBeacon` that subscribes to the stream returned from its callback and updates its value based on the emitted values.
+When a dependency changes, the beacon will unsubscribe from the old stream and subscribe to the new one.
+
+If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
+It will cancel the stream subscription and enter a sleep state.
+It will resume executing once a listener is added or its value is accessed.
+
+Example:
+
+```dart
+final userID = Beacon.writable<int>(18235);
+
+final profileBeacon = Beacon.derivedStream(() {
+ return getProfileStreamFromUID(userID.value);
+});
+```
+
 ### Beacon.derivedFuture:
 
 Creates a `DerivedBeacon` whose value is derived from an asynchronous computation.
@@ -242,7 +262,7 @@ If `cancelRunning` is `true` (default), the results of a current execution will 
 if another execution is triggered before the current one finishes.
 
 If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
-It will resume executing once a listener is added or it's value is accessed.
+It will resume executing once a listener is added or its value is accessed.
 This means that it will enter the `loading` state when woken up.
 
 Example:
@@ -579,7 +599,7 @@ print(myBeacon.value); // Outputs AsyncData('Hello')
 
 #### AsyncValue.unwrap():
 
-Casts this [AsyncValue] to [AsyncData] and return it's value. This will throw an error if the value is not an [AsyncData].
+Casts this [AsyncValue] to [AsyncData] and return its value. This will throw an error if the value is not an [AsyncData].
 
 ```dart
 var name = AsyncData('Bob');

--- a/packages/state_beacon/README.md
+++ b/packages/state_beacon/README.md
@@ -99,6 +99,7 @@ NB: Create the file if it doesn't exist.
 -   [Beacon.readable](#beaconreadable): Immutable beacon that only emit values, ideal for readonly data.
 -   [Beacon.effect](#beaconcreateeffect): React to changes in beacon values.
 -   [Beacon.derived](#beaconderived): Derive values from other beacons, keeping them reactively in sync.
+-   [Beacon.derivedStream](#beaconderivedstream): Specialized derived beacon that subscribes to the stream returned from its callback and updates its value based on the emitted values.
 -   [Beacon.derivedFuture](#beaconderivedfuture): Derive values from asynchronous operations, managing state during computation.
 -   [Beacon.future](#beaconfuture): Initialize beacons from futures.
     -   [overrideWith](#futurebeaconoverridewith): Replace the callback.
@@ -116,7 +117,7 @@ NB: Create the file if it doesn't exist.
     -   [Beacon.hashSet](#beaconhashset): Like Beacon.list, but for Sets.
     -   [Beacon.hashMap](#beaconhashmap): Like Beacon.list, but for Maps.
 -   [AsyncValue](#asyncvalue): A wrapper around a value that can be in one of four states: `idle`, `loading`, `data`, or `error`.
-    -   [unwrap](#asyncvalueunwrap): Casts this [AsyncValue] to [AsyncData] and return it's value.
+    -   [unwrap](#asyncvalueunwrap): Casts this [AsyncValue] to [AsyncData] and return its value.
     -   [lastData](#asyncvaluelastdata): Returns the latest valid data value or null.
     -   [tryCatch](#asyncvaluetrycatch): Execute a future and return [AsyncData] or [AsyncError].
     -   [optimistic updates](#asyncvaluetrycatch): Update the value optimistically when using tryCatch.
@@ -212,7 +213,7 @@ Creates a `DerivedBeacon` whose value is derived from a computation function.
 This beacon will recompute its value every time one of it's dependencies change.
 
 If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
-It will resume executing once a listener is added or it's value is accessed.
+It will resume executing once a listener is added or its value is accessed.
 
 If `supportConditional` is `false`(default: true), it will only look dependencies on its first run.
 This means once a beacon is added as a dependency, it will not be removed even if it's no longer used and no new dependencies will be added. This can be used a performance optimization.
@@ -230,6 +231,25 @@ age.value = 22;
 print(canDrink.value); // Outputs: true
 ```
 
+### Beacon.derivedStream:
+
+Specialized `DerivedBeacon` that subscribes to the stream returned from its callback and updates its value based on the emitted values.
+When a dependency changes, the beacon will unsubscribe from the old stream and subscribe to the new one.
+
+If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
+It will cancel the stream subscription and enter a sleep state.
+It will resume executing once a listener is added or its value is accessed.
+
+Example:
+
+```dart
+final userID = Beacon.writable<int>(18235);
+
+final profileBeacon = Beacon.derivedStream(() {
+ return getProfileStreamFromUID(userID.value);
+});
+```
+
 ### Beacon.derivedFuture:
 
 Creates a `DerivedBeacon` whose value is derived from an asynchronous computation.
@@ -242,7 +262,7 @@ If `cancelRunning` is `true` (default), the results of a current execution will 
 if another execution is triggered before the current one finishes.
 
 If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
-It will resume executing once a listener is added or it's value is accessed.
+It will resume executing once a listener is added or its value is accessed.
 This means that it will enter the `loading` state when woken up.
 
 Example:
@@ -579,7 +599,7 @@ print(myBeacon.value); // Outputs AsyncData('Hello')
 
 #### AsyncValue.unwrap():
 
-Casts this [AsyncValue] to [AsyncData] and return it's value. This will throw an error if the value is not an [AsyncData].
+Casts this [AsyncValue] to [AsyncData] and return its value. This will throw an error if the value is not an [AsyncData].
 
 ```dart
 var name = AsyncData('Bob');

--- a/packages/state_beacon_core/README.md
+++ b/packages/state_beacon_core/README.md
@@ -92,6 +92,7 @@ NB: Create the file if it doesn't exist.
 -   [Beacon.readable](#beaconreadable): Immutable beacon that only emit values, ideal for readonly data.
 -   [Beacon.effect](#beaconcreateeffect): React to changes in beacon values.
 -   [Beacon.derived](#beaconderived): Derive values from other beacons, keeping them reactively in sync.
+-   [Beacon.derivedStream](#beaconderivedstream): Specialized derived beacon that subscribes to the stream returned from its callback and updates its value based on the emitted values.
 -   [Beacon.derivedFuture](#beaconderivedfuture): Derive values from asynchronous operations, managing state during computation.
 -   [Beacon.future](#beaconfuture): Initialize beacons from futures.
     -   [overrideWith](#futurebeaconoverridewith): Replace the callback.
@@ -109,7 +110,7 @@ NB: Create the file if it doesn't exist.
     -   [Beacon.hashSet](#beaconhashset): Like Beacon.list, but for Sets.
     -   [Beacon.hashMap](#beaconhashmap): Like Beacon.list, but for Maps.
 -   [AsyncValue](#asyncvalue): A wrapper around a value that can be in one of four states: `idle`, `loading`, `data`, or `error`.
-    -   [unwrap](#asyncvalueunwrap): Casts this [AsyncValue] to [AsyncData] and return it's value.
+    -   [unwrap](#asyncvalueunwrap): Casts this [AsyncValue] to [AsyncData] and return its value.
     -   [lastData](#asyncvaluelastdata): Returns the latest valid data value or null.
     -   [tryCatch](#asyncvaluetrycatch): Execute a future and return [AsyncData] or [AsyncError].
     -   [optimistic updates](#asyncvaluetrycatch): Update the value optimistically when using tryCatch.
@@ -205,7 +206,7 @@ Creates a `DerivedBeacon` whose value is derived from a computation function.
 This beacon will recompute its value every time one of it's dependencies change.
 
 If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
-It will resume executing once a listener is added or it's value is accessed.
+It will resume executing once a listener is added or its value is accessed.
 
 If `supportConditional` is `false`(default: true), it will only look dependencies on its first run.
 This means once a beacon is added as a dependency, it will not be removed even if it's no longer used and no new dependencies will be added. This can be used a performance optimization.
@@ -223,6 +224,25 @@ age.value = 22;
 print(canDrink.value); // Outputs: true
 ```
 
+### Beacon.derivedStream:
+
+Specialized `DerivedBeacon` that subscribes to the stream returned from its callback and updates its value based on the emitted values.
+When a dependency changes, the beacon will unsubscribe from the old stream and subscribe to the new one.
+
+If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
+It will cancel the stream subscription and enter a sleep state.
+It will resume executing once a listener is added or its value is accessed.
+
+Example:
+
+```dart
+final userID = Beacon.writable<int>(18235);
+
+final profileBeacon = Beacon.derivedStream(() {
+ return getProfileStreamFromUID(userID.value);
+});
+```
+
 ### Beacon.derivedFuture:
 
 Creates a `DerivedBeacon` whose value is derived from an asynchronous computation.
@@ -235,7 +255,7 @@ If `cancelRunning` is `true` (default), the results of a current execution will 
 if another execution is triggered before the current one finishes.
 
 If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
-It will resume executing once a listener is added or it's value is accessed.
+It will resume executing once a listener is added or its value is accessed.
 This means that it will enter the `loading` state when woken up.
 
 Example:
@@ -572,7 +592,7 @@ print(myBeacon.value); // Outputs AsyncData('Hello')
 
 #### AsyncValue.unwrap():
 
-Casts this [AsyncValue] to [AsyncData] and return it's value. This will throw an error if the value is not an [AsyncData].
+Casts this [AsyncValue] to [AsyncData] and return its value. This will throw an error if the value is not an [AsyncData].
 
 ```dart
 var name = AsyncData('Bob');

--- a/packages/state_beacon_core/lib/src/creator/beacon_creator.dart
+++ b/packages/state_beacon_core/lib/src/creator/beacon_creator.dart
@@ -424,7 +424,7 @@ class _BeaconCreator {
   /// This beacon will recompute its value every time one of it's dependencies change.
   ///
   /// If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
-  /// It will resume executing once a listener is added or it's value is accessed.
+  /// It will resume executing once a listener is added or its value is accessed.
   ///
   /// If `supportConditional` is `false`(default: true), it will only look dependencies on its first run.
   /// This means once a beacon is added as a dependency, it will not be removed even if it's no longer used and no new dependencies will be added. This can be used as a performance optimization.
@@ -475,7 +475,7 @@ class _BeaconCreator {
   ///
   /// If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
   /// It will cancel the stream subscription and enter a sleep state.
-  /// It will resume executing once a listener is added or it's value is accessed.
+  /// It will resume executing once a listener is added or its value is accessed.
   ///
   /// If `supportConditional` is `false`(default: true), it will only look dependencies on its first run.
   /// This means once a beacon is added as a dependency, it will not be removed even if it's no longer used and no new dependencies will be added. This can be used as a performance optimization.
@@ -538,7 +538,7 @@ class _BeaconCreator {
   /// if another execution is triggered before the current one finishes.
   ///
   /// If `shouldSleep` is `true`(default), the callback will not execute if the beacon is no longer being watched.
-  /// It will resume executing once a listener is added or it's value is accessed.
+  /// It will resume executing once a listener is added or its value is accessed.
   /// This means that it will enter the `loading` state when woken up.
   ///
   ///

--- a/packages/state_beacon_core/lib/src/creator/beacon_group_creator.dart
+++ b/packages/state_beacon_core/lib/src/creator/beacon_group_creator.dart
@@ -386,4 +386,23 @@ class BeaconGroup extends _BeaconCreator {
       }
     }
   }
+
+  @override
+  ReadableBeacon<T> derivedStream<T>(
+    Stream<T> Function() compute, {
+    String? name,
+    bool shouldSleep = true,
+    bool supportConditional = true,
+    bool cancelOnError = false,
+  }) {
+    final beacon = super.derivedStream<T>(
+      compute,
+      name: name,
+      shouldSleep: shouldSleep,
+      supportConditional: supportConditional,
+      cancelOnError: cancelOnError,
+    );
+    _beacons.add(beacon);
+    return beacon;
+  }
 }

--- a/packages/state_beacon_core/lib/src/creator/creator.dart
+++ b/packages/state_beacon_core/lib/src/creator/creator.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:state_beacon_core/src/beacons/family.dart';
 import 'package:state_beacon_core/src/untracked.dart';
 

--- a/packages/state_beacon_core/test/src/beacons/derived_stream_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/derived_stream_test.dart
@@ -1,0 +1,90 @@
+import 'dart:async';
+
+import 'package:state_beacon_core/state_beacon_core.dart';
+import 'package:test/test.dart';
+
+import '../../common.dart';
+
+void main() {
+  Stream<int> sampleStream(int len) {
+    return Stream.fromIterable(List.generate(len, (i) => i));
+  }
+
+  void addItems(StreamController<int> controller, int len) {
+    for (var i = 0; i < len; i++) {
+      controller.add(i);
+    }
+  }
+
+  test('should set values emitted by stream', () async {
+    final beacon = Beacon.derivedStream(() {
+      return sampleStream(5);
+    });
+
+    final buff = beacon.bufferTime(duration: k1ms);
+
+    expect(buff.value, isEmpty);
+
+    await delay();
+
+    expect(buff.value, [0, 1, 2, 3, 4]);
+  });
+
+  test('should unsub from old stream when dependency changes', () async {
+    final controller = StreamController<int>.broadcast();
+
+    final counter = Beacon.writable(5);
+
+    var unsubs = 0;
+    var listens = 0;
+
+    controller.onCancel = () {
+      // print('unsub');
+      unsubs++;
+    };
+
+    controller.onListen = () {
+      // print('listen');
+      listens++;
+      addItems(controller, counter.value);
+    };
+
+    final beacon = Beacon.derivedStream(() {
+      counter.value;
+      return controller.stream;
+    });
+
+    expect(listens, 1);
+
+    final buff = beacon.bufferTime(duration: k1ms);
+
+    expect(buff.value, isEmpty);
+
+    await delay();
+
+    expect(buff.value, [0, 1, 2, 3, 4]);
+
+    counter.increment(); // dep changed, should unsub from old stream
+
+    await delay();
+
+    expect(unsubs, 1);
+    expect(listens, 2);
+
+    expect(buff.value, [0, 1, 2, 3, 4, 5]);
+
+    counter.increment();
+
+    await delay();
+
+    expect(unsubs, 2); // dep changed, should unsub from old stream
+    expect(listens, 3);
+
+    expect(buff.value, [0, 1, 2, 3, 4, 5, 6]);
+
+    beacon.dispose(); // should unsub when disposed
+
+    expect(unsubs, 3);
+    expect(listens, 3);
+  });
+}

--- a/packages/state_beacon_core/test/src/beacons/derived_stream_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/derived_stream_test.dart
@@ -35,6 +35,7 @@ void main() {
 
     final counter = Beacon.writable(5);
 
+    // should increment when dependency changes
     var unsubs = 0;
     var listens = 0;
 

--- a/packages/state_beacon_core/test/src/beacons/derived_stream_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/derived_stream_test.dart
@@ -25,9 +25,7 @@ void main() {
 
     expect(buff.value, isEmpty);
 
-    await delay();
-
-    expect(buff.value, [0, 1, 2, 3, 4]);
+    await expectLater(buff.next(), completion([0, 1, 2, 3, 4]));
   });
 
   test('should unsub from old stream when dependency changes', () async {
@@ -39,10 +37,7 @@ void main() {
     var unsubs = 0;
     var listens = 0;
 
-    controller.onCancel = () {
-      // print('unsub');
-      unsubs++;
-    };
+    controller.onCancel = () => unsubs++;
 
     controller.onListen = () {
       // print('listen');

--- a/packages/state_beacon_core/test/src/beacons/derived_stream_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/derived_stream_test.dart
@@ -61,27 +61,21 @@ void main() {
 
     expect(buff.value, isEmpty);
 
-    await delay();
-
-    expect(buff.value, [0, 1, 2, 3, 4]);
+    await expectLater(buff.next(), completion([0, 1, 2, 3, 4]));
 
     counter.increment(); // dep changed, should unsub from old stream
-
-    await delay();
 
     expect(unsubs, 1);
     expect(listens, 2);
 
-    expect(buff.value, [0, 1, 2, 3, 4, 5]);
+    await expectLater(buff.next(), completion([0, 1, 2, 3, 4, 5]));
 
     counter.increment();
-
-    await delay();
 
     expect(unsubs, 2); // dep changed, should unsub from old stream
     expect(listens, 3);
 
-    expect(buff.value, [0, 1, 2, 3, 4, 5, 6]);
+    await expectLater(buff.next(), completion([0, 1, 2, 3, 4, 5, 6]));
 
     beacon.dispose(); // should unsub when disposed
 

--- a/packages/state_beacon_core/test/src/creator/beacon_group_creator_test.dart
+++ b/packages/state_beacon_core/test/src/creator/beacon_group_creator_test.dart
@@ -33,13 +33,14 @@ void main() {
     final hashSet = group.hashSet<int>({0});
     final hashMap = group.hashMap<int, int>({0: 0});
     final derivedFuture = group.derivedFuture<int>(() async => filtered() + 1);
+    final derivedStream = group.derivedStream(Stream.empty);
 
     final dispose = group.effect(() {});
 
     // ignore: inference_failure_on_function_invocation, unnecessary_lambdas
     final family = group.family((int i) => group.readable(i));
 
-    expect(group.beaconCount, 24);
+    expect(group.beaconCount, 25);
 
     writable.increment();
 
@@ -78,6 +79,7 @@ void main() {
     expect(hashSet.isDisposed, true);
     expect(hashMap.isDisposed, true);
     expect(derivedFuture.isDisposed, true);
+    expect(derivedStream.isDisposed, true);
 
     expect(group.beaconCount, 0);
   });


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->

Specialized `DerivedBeacon` that subscribes to the stream returned from its callback and updates its value based on the emitted values.
When a dependency changes, the beacon will unsubscribe from the old stream and subscribe to the new one.

Example:
```dart
final userID = Beacon.writable<int>(18235);
final profileBeacon = Beacon.derivedStream(() {
 return getProfileStreamFromUID(userID.value);
});
```

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
