### PR TITLE
[Feat] Allow stream beacons to be start manually

### DIFF
--- a/packages/state_beacon_core/lib/src/beacons/async.dart
+++ b/packages/state_beacon_core/lib/src/beacons/async.dart
@@ -35,4 +35,42 @@ abstract class AsyncBeacon<T> extends ReadableBeacon<AsyncValue<T>> {
     _Awaited.remove(this);
     super.dispose();
   }
+
+  /// Alias for peek().lastData.
+  /// Returns the last data that was successfully loaded
+  /// equivalent to `beacon.peek().lastData`
+  T? get lastData => peek().lastData;
+
+  /// Casts its value to [AsyncData] and return
+  /// it's value or throws `CastError` if this is not [AsyncData].
+  /// equivalent to `beacon.peek().unwrap()`
+  T unwrapValue() => peek().unwrap();
+
+  /// Returns `true` if this is [AsyncLoading].
+  /// This is equivalent to `beacon.peek().isLoading`.
+  bool get isLoading => peek().isLoading;
+
+  /// Returns `true` if this is [AsyncIdle].
+  /// This is equivalent to `beacon.peek().isIdle`.
+  bool get isIdle => peek().isIdle;
+
+  /// Returns `true` if this is [AsyncIdle] or [AsyncLoading].
+  /// This is equivalent to `beacon.peek().isIdleOrLoading`.
+  bool get isIdleOrLoading => peek().isIdleOrLoading;
+
+  /// Returns `true` if this is [AsyncData].
+  /// This is equivalent to `beacon.peek().isData`.
+  bool get isData => peek().isData;
+
+  /// Returns `true` if this is [AsyncError].
+  /// This is equivalent to `beacon.peek().isError`.
+  bool get isError => peek().isError;
+
+  void _setLoadingWithLastData() {
+    _setValue(AsyncLoading()..setLastData(lastData));
+  }
+
+  void _setErrorWithLastData(Object error, [StackTrace? stackTrace]) {
+    _setValue(AsyncError(error, stackTrace)..setLastData(lastData));
+  }
 }

--- a/packages/state_beacon_core/lib/src/beacons/future.dart
+++ b/packages/state_beacon_core/lib/src/beacons/future.dart
@@ -18,49 +18,16 @@ abstract class FutureBeacon<T> extends AsyncBeacon<T> {
 
   final bool _cancelRunning;
 
-  /// Alias for peek().lastData.
-  /// Returns the last data that was successfully loaded
-  /// equivalent to `beacon.peek().lastData`
-  T? get lastData => peek().lastData;
-
   FutureCallback<T> _operation;
 
-  /// Casts its value to [AsyncData] and return
-  /// it's value or throws `CastError` if this is not [AsyncData].
-  /// equivalent to `beacon.peek().unwrap()`
-  T unwrapValue() => peek().unwrap();
-
-  /// Returns `true` if this is [AsyncLoading].
-  /// This is equivalent to `beacon.peek().isLoading`.
-  bool get isLoading => peek().isLoading;
-
-  /// Returns `true` if this is [AsyncIdle].
-  /// This is equivalent to `beacon.peek().isIdle`.
-  bool get isIdle => peek().isIdle;
-
-  /// Returns `true` if this is [AsyncIdle] or [AsyncLoading].
-  /// This is equivalent to `beacon.peek().isIdleOrLoading`.
-  bool get isIdleOrLoading => peek().isIdleOrLoading;
-
-  /// Returns `true` if this is [AsyncData].
-  /// This is equivalent to `beacon.peek().isData`.
-  bool get isData => peek().isData;
-
-  /// Returns `true` if this is [AsyncError].
-  /// This is equivalent to `beacon.peek().isError`.
-  bool get isError => peek().isError;
-
   /// Starts executing an idle [Future]
-  ///
-  /// NB: Must only be called once
+  /// Calling more than once has no effect
   ///
   /// Use [reset] to restart the [Future]
   void start();
 
   int _startLoading() {
-    _setValue(
-      AsyncLoading()..setLastData(lastData),
-    );
+    _setLoadingWithLastData();
     return ++_executionID;
   }
 

--- a/packages/state_beacon_core/lib/src/creator/beacon_creator.dart
+++ b/packages/state_beacon_core/lib/src/creator/beacon_creator.dart
@@ -358,11 +358,13 @@ class _BeaconCreator {
   StreamBeacon<T> stream<T>(
     Stream<T> stream, {
     bool cancelOnError = false,
+    bool manualStart = false,
     String? name,
   }) {
     return StreamBeacon<T>(
       stream,
       cancelOnError: cancelOnError,
+      manualStart: manualStart,
       name: name ?? 'StreamBeacon<$T>',
     );
   }

--- a/packages/state_beacon_core/lib/src/creator/beacon_group_creator.dart
+++ b/packages/state_beacon_core/lib/src/creator/beacon_group_creator.dart
@@ -280,11 +280,13 @@ class BeaconGroup extends _BeaconCreator {
   StreamBeacon<T> stream<T>(
     Stream<T> stream, {
     bool cancelOnError = false,
+    bool manualStart = false,
     String? name,
   }) {
     final beacon = super.stream<T>(
       stream,
       cancelOnError: cancelOnError,
+      manualStart: manualStart,
       name: name,
     );
     _beacons.add(beacon);

--- a/packages/state_beacon_core/test/src/beacons/future_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/future_test.dart
@@ -108,4 +108,32 @@ void main() {
 
     expect(futureBeacon.isError, isTrue);
   });
+
+  test('should set last data in loading and error states', () async {
+    final controller = StreamController<int>.broadcast();
+
+    final myBeacon = Beacon.future(() => controller.stream.first);
+
+    expect(myBeacon.isLoading, true);
+
+    controller.add(10);
+
+    var next = await myBeacon.next();
+
+    expect(next.unwrap(), 10);
+
+    myBeacon.overrideWith(() => controller.stream.first);
+
+    expect(myBeacon.isLoading, true);
+
+    expect(next.lastData, 10);
+
+    controller.addError(Exception('error'));
+
+    next = await myBeacon.next();
+
+    expect(next.isError, true);
+
+    expect(next.lastData, 10);
+  });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

The beacon will start in the `idle` state when manualStart is set to true.

```dart
test('should not start stream until start() is called', () async {
    final myStream = Stream.periodic(k10ms, (i) => i + 1);
    final myBeacon = Beacon.stream(myStream, manualStart: true);

    expect(myBeacon.isIdle, true);

    myBeacon.start();

    expect(myBeacon.isLoading, true);

    final next = await myBeacon.next();

    expect(next.isData, true);
  });
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
