### PR TITLE
[Feat] Add map to chain methods

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -857,6 +857,28 @@ Returns a [Beacon.throttled](#beaconthrottled) that wraps this beacon.
 
 Returns a [Beacon.filtered](#beaconfiltered) that wraps this beacon.
 
+### mybeacon.map():
+
+Returns a [ReadableBeacon] that wraps a Beacon and tranforms its values.
+
+```dart
+final stream = Stream.periodic(k1ms, (i) => i).take(5);
+final beacon = stream
+    .toRawBeacon(isLazy: true)
+    .map((v) => v + 1)
+    .filter(filter: (_, n) => n.isEven);
+
+await expectLater(beacon.stream, emitsInOrder([1, 2, 4]));
+```
+
+> [!NOTE]
+> When `map` returns a different type, writes to the returned beacon will not be re-routed to the original beacon. In the example below, writes to `filteredBeacon` will NOT be re-routed to `count` because `map` returns a `String` and `count` holds an `int`.
+
+```dart
+final count = Beacon.writable(0);
+final filteredBeacon = count.map((v) => '$v').filter(filter: (_, n) => n.length > 1);
+```
+
 ### mybeacon.debounce():
 
 Returns a [Beacon.debounced](#beacondebounced) that wraps this beacon.

--- a/packages/state_beacon/README.md
+++ b/packages/state_beacon/README.md
@@ -857,6 +857,28 @@ Returns a [Beacon.throttled](#beaconthrottled) that wraps this beacon.
 
 Returns a [Beacon.filtered](#beaconfiltered) that wraps this beacon.
 
+### mybeacon.map():
+
+Returns a [ReadableBeacon] that wraps a Beacon and tranforms its values.
+
+```dart
+final stream = Stream.periodic(k1ms, (i) => i).take(5);
+final beacon = stream
+    .toRawBeacon(isLazy: true)
+    .map((v) => v + 1)
+    .filter(filter: (_, n) => n.isEven);
+
+await expectLater(beacon.stream, emitsInOrder([1, 2, 4]));
+```
+
+> [!NOTE]
+> When `map` returns a different type, writes to the returned beacon will not be re-routed to the original beacon. In the example below, writes to `filteredBeacon` will NOT be re-routed to `count` because `map` returns a `String` and `count` holds an `int`.
+
+```dart
+final count = Beacon.writable(0);
+final filteredBeacon = count.map((v) => '$v').filter(filter: (_, n) => n.length > 1);
+```
+
 ### mybeacon.debounce():
 
 Returns a [Beacon.debounced](#beacondebounced) that wraps this beacon.

--- a/packages/state_beacon_core/README.md
+++ b/packages/state_beacon_core/README.md
@@ -853,6 +853,28 @@ Returns a [Beacon.throttled](#beaconthrottled) that wraps this beacon.
 
 Returns a [Beacon.filtered](#beaconfiltered) that wraps this beacon.
 
+### mybeacon.map():
+
+Returns a [ReadableBeacon] that wraps a Beacon and tranforms its values.
+
+```dart
+final stream = Stream.periodic(k1ms, (i) => i).take(5);
+final beacon = stream
+    .toRawBeacon(isLazy: true)
+    .map((v) => v + 1)
+    .filter(filter: (_, n) => n.isEven);
+
+await expectLater(beacon.stream, emitsInOrder([1, 2, 4]));
+```
+
+> [!NOTE]
+> When `map` returns a different type, writes to the returned beacon will not be re-routed to the original beacon. In the example below, writes to `filteredBeacon` will NOT be re-routed to `count` because `map` returns a `String` and `count` holds an `int`.
+
+```dart
+final count = Beacon.writable(0);
+final filteredBeacon = count.map((v) => '$v').filter(filter: (_, n) => n.length > 1);
+```
+
 ### mybeacon.debounce():
 
 Returns a [Beacon.debounced](#beacondebounced) that wraps this beacon.

--- a/packages/state_beacon_core/lib/src/beacons/buffered.dart
+++ b/packages/state_beacon_core/lib/src/beacons/buffered.dart
@@ -34,6 +34,7 @@ abstract class BufferedBaseBeacon<T> extends ReadableBeacon<List<T>>
   void _internalAdd(T newValue, {bool delegated = false});
 
   /// Clears the buffer
+  @override
   void reset({bool force = false}) {
     _clearBuffer();
     _setValue(_initialValue, force: force);

--- a/packages/state_beacon_core/lib/src/beacons/mapped.dart
+++ b/packages/state_beacon_core/lib/src/beacons/mapped.dart
@@ -1,0 +1,48 @@
+// ignore_for_file: use_setters_to_change_properties
+
+part of '../producer.dart';
+
+// ignore: public_member_api_docs
+typedef MapFilter<I, O> = O Function(I);
+
+/// A beacon that transforms all values before setting them.
+class _MappedBeacon<I, O> extends ReadableBeacon<O> with BeaconWrapper<I, O> {
+  _MappedBeacon(
+    this.mapFN, {
+    super.initialValue,
+    super.name,
+  });
+
+  final MapFilter<I, O> mapFN;
+
+  @override
+  void set(I newValue, {bool force = false}) {
+    _internalSet(newValue, force: force, delegated: true);
+  }
+
+  void _internalSet(I newValue, {bool force = false, bool delegated = false}) {
+    if (delegated && _delegate != null) {
+      _delegate!.set(newValue, force: true);
+      return;
+    }
+
+    _setValue(mapFN(newValue), force: force);
+  }
+
+  @override
+  void _onNewValueFromWrapped(I value) {
+    _internalSet(value);
+  }
+
+  @override
+  void reset({bool force = false}) {
+    if (_isEmpty) return;
+
+    if (_delegate != null) {
+      _delegate!.reset(force: force);
+      // return;
+    }
+
+    _setValue(_initialValue, force: force);
+  }
+}

--- a/packages/state_beacon_core/lib/src/beacons/writable.dart
+++ b/packages/state_beacon_core/lib/src/beacons/writable.dart
@@ -11,6 +11,7 @@ class WritableBeacon<T> extends ReadableBeacon<T> with BeaconWrapper<T, T> {
 
   /// Set the beacon to its initial value
   /// and notify all listeners
+  @override
   void reset({bool force = false}) {
     if (_isEmpty) return;
 
@@ -23,6 +24,7 @@ class WritableBeacon<T> extends ReadableBeacon<T> with BeaconWrapper<T, T> {
   }
 
   /// Sets the value of the beacon and allows a force notification
+  @override
   void set(T newValue, {bool force = false}) {
     _internalSet(newValue, force: force, delegated: true);
   }

--- a/packages/state_beacon_core/lib/src/extensions/chain.dart
+++ b/packages/state_beacon_core/lib/src/extensions/chain.dart
@@ -241,6 +241,44 @@ final beacon = Beacon.filtered<T>(0).wrap(someBufferedBeacon)
     return beacon;
   }
 
+  /// Returns a [FilteredBeacon] that wraps this Beacon.
+  ///
+  /// NB: All writes to the filtered beacon
+  /// will be delegated to the wrapped beacon.
+  ///
+  /// ```dart
+  /// final count = Beacon.writable(10);
+  /// final filteredCount = count.filter(filter: (prev, next) => next > 10);
+  ///
+  /// filteredCount.value = 20; //  equivalent to count.set(20, force: true);
+  ///
+  /// expect(count.value, equals(20));
+  /// expect(filteredCount.value, equals(20));
+  /// ```
+  /// See: `Beacon.filtered` for more details.
+  ReadableBeacon<O> map<O>(
+    MapFilter<T, O> mapFN, {
+    String? name,
+  }) {
+    assert(
+      this is! BufferedBaseBeacon,
+      '''
+Chaining of buffered beacons is not supported!
+Buffered beacons has to be the last in the chain.
+
+Good: someBeacon.map().buffer(10);
+
+Bad: someBeacon.buffer(10).map();
+''',
+    );
+
+    final beacon = _MappedBeacon(mapFN, name: name);
+
+    _wrapAndDelegate(beacon);
+
+    return beacon;
+  }
+
   void _wrapAndDelegate<InputT, OutputT>(
     BeaconWrapper<InputT, OutputT> beacon,
   ) {
@@ -251,7 +289,10 @@ final beacon = Beacon.filtered<T>(0).wrap(someBufferedBeacon)
     );
 
     if (this is WritableBeacon<InputT>) {
-      beacon._delegate = this as WritableBeacon<InputT>;
+      beacon._delegate = this as BeaconWrapper<InputT, dynamic>;
+    } else if (this is _MappedBeacon<InputT, InputT>) {
+      // if map output is the same as the input, then we can delegate
+      beacon._delegate = this as _MappedBeacon<InputT, InputT>;
     }
   }
 }

--- a/packages/state_beacon_core/lib/src/extensions/chain.dart
+++ b/packages/state_beacon_core/lib/src/extensions/chain.dart
@@ -241,21 +241,22 @@ final beacon = Beacon.filtered<T>(0).wrap(someBufferedBeacon)
     return beacon;
   }
 
-  /// Returns a [FilteredBeacon] that wraps this Beacon.
+  /// Returns a [ReadableBeacon] that wraps a Beacon and tranforms its values.
   ///
   /// NB: All writes to the filtered beacon
   /// will be delegated to the wrapped beacon.
   ///
   /// ```dart
   /// final count = Beacon.writable(10);
-  /// final filteredCount = count.filter(filter: (prev, next) => next > 10);
+  /// final mapped = count.map((value) => value * 2);
   ///
-  /// filteredCount.value = 20; //  equivalent to count.set(20, force: true);
+  /// expect(mapped.value, 20);
   ///
-  /// expect(count.value, equals(20));
-  /// expect(filteredCount.value, equals(20));
+  /// count.value = 20;
+  ///
+  /// expect(count.value, 20);
+  /// expect(mapped.value, 40);
   /// ```
-  /// See: `Beacon.filtered` for more details.
   ReadableBeacon<O> map<O>(
     MapFilter<T, O> mapFN, {
     String? name,

--- a/packages/state_beacon_core/lib/src/mixins/beacon_wrapper.dart
+++ b/packages/state_beacon_core/lib/src/mixins/beacon_wrapper.dart
@@ -8,7 +8,7 @@ part of '../producer.dart';
 mixin BeaconWrapper<InputT, OutputT> on ReadableBeacon<OutputT> {
   final _wrapped = <int, VoidCallback>{};
 
-  WritableBeacon<InputT>? _delegate;
+  BeaconWrapper<InputT, dynamic>? _delegate;
 
   /// Disposes all currently wrapped beacons
   void clearWrapped() {
@@ -21,4 +21,14 @@ mixin BeaconWrapper<InputT, OutputT> on ReadableBeacon<OutputT> {
   /// Wrapper beacons can have different methods to set the value,
   /// so this is should be implemented by the wrapper.
   void _onNewValueFromWrapped(InputT value);
+
+  /// Sets the delegate beacon to listen to.
+  void set(InputT value, {bool force = false}) {
+    throw UnimplementedError();
+  }
+
+  /// Wraps a beacon and listens to its changes.
+  void reset({bool force = false}) {
+    throw UnimplementedError();
+  }
 }

--- a/packages/state_beacon_core/lib/src/mixins/beacon_wrapper.dart
+++ b/packages/state_beacon_core/lib/src/mixins/beacon_wrapper.dart
@@ -22,13 +22,13 @@ mixin BeaconWrapper<InputT, OutputT> on ReadableBeacon<OutputT> {
   /// so this is should be implemented by the wrapper.
   void _onNewValueFromWrapped(InputT value);
 
+  // coverage:ignore-start
   /// Sets the delegate beacon to listen to.
   void set(InputT value, {bool force = false}) {
     throw UnimplementedError();
   }
+  // coverage:ignore-end
 
   /// Wraps a beacon and listens to its changes.
-  void reset({bool force = false}) {
-    throw UnimplementedError();
-  }
+  void reset({bool force = false});
 }

--- a/packages/state_beacon_core/lib/src/producer.dart
+++ b/packages/state_beacon_core/lib/src/producer.dart
@@ -48,6 +48,7 @@ part 'beacons/debounced.dart';
 part 'beacons/derived.dart';
 part 'beacons/family.dart';
 part 'beacons/filtered.dart';
+part 'beacons/mapped.dart';
 part 'beacons/future.dart';
 part 'beacons/list.dart';
 part 'beacons/map.dart';

--- a/packages/state_beacon_core/test/src/extensions/chain_test.dart
+++ b/packages/state_beacon_core/test/src/extensions/chain_test.dart
@@ -472,6 +472,17 @@ void main() {
     await expectLater(beacon.stream, emitsInOrder([1, 2, 4]));
   });
 
+  test('should transform input values when use mid-chain/2', () async {
+    final stream = Stream.periodic(k1ms, (i) => i).take(5);
+    final beacon = stream
+        .toRawBeacon(isLazy: true)
+        .filter(filter: (_, n) => n.isEven)
+        .map((v) => v + 1)
+        .throttle(duration: k1ms);
+
+    await expectLater(beacon.stream, emitsInOrder([1, 3, 5]));
+  });
+
   test('should not delegate to map beacon when output type differs', () {
     final count = Beacon.writable<int>(10);
 


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

```dart
final count = Beacon.writable(10);
final mapped = count.map((value) => value * 2);

expect(mapped.value, 20);

count.value = 20;

expect(count.value, 20);
expect(mapped.value, 40);
```

```dart
final stream = Stream.periodic(k1ms, (i) => i).take(5);
final beacon = stream
        .toRawBeacon(isLazy: true)
        .filter(filter: (_, n) => n.isEven)
        .map((v) => v + 1)
        .throttle(duration: k1ms);

await expectLater(beacon.stream, emitsInOrder([1, 3, 5]));
```

<!--- Describe your changes in detail -->

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
