### PR TITLE
Improve .next() and remove deprecated method ,toStream()

### DIFF
--- a/packages/state_beacon_core/lib/src/producer.dart
+++ b/packages/state_beacon_core/lib/src/producer.dart
@@ -195,10 +195,15 @@ abstract class Producer<T> {
   }
 
   /// Registers a callback to be called when the beacon is disposed.
-  void onDispose(VoidCallback callback) {
-    if (isDisposed) return;
+  /// Returns a function that can be called to remove the callback.
+  VoidCallback onDispose(VoidCallback callback) {
+    assert(!_isDisposed, 'Cannot add a dispose callback to a disposed beacon.');
 
     _disposeCallbacks.add(callback);
+
+    return () {
+      _disposeCallbacks.remove(callback);
+    };
   }
 
   /// Clears all registered listeners and

--- a/packages/state_beacon_core/test/src/beacons/stream_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/stream_test.dart
@@ -125,7 +125,7 @@ void main() {
 
     controller.addError('error');
 
-    next = await myBeacon.next(timeout: k1ms);
+    next = await myBeacon.next();
 
     expect(next.isError, true);
 

--- a/packages/state_beacon_core/test/src/core_test.dart
+++ b/packages/state_beacon_core/test/src/core_test.dart
@@ -487,4 +487,33 @@ void main() {
       expect(beacon.initialValue, equals([]));
     });
   });
+
+  test('should run dispose callback', () {
+    final a = Beacon.writable(10);
+    var ran = 0;
+
+    a.onDispose(() {
+      ran++;
+    });
+
+    a.dispose();
+    expect(ran, 1);
+    a.dispose(); // should not run again
+    expect(ran, 1);
+  });
+
+  test('should remove dispose callback', () {
+    final a = Beacon.writable(10);
+    var ran = 0;
+
+    final cancel = a.onDispose(() {
+      ran++;
+    });
+
+    cancel();
+
+    a.dispose();
+
+    expect(ran, 0);
+  });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

<!--- Describe your changes in detail -->
### Remove deprecated method `toStream()` use `.stream` instead

### Improve beacon.next()
-  Remove timeout parameter
-  Complete with current value when beacon is disposed
-  Throws if lazybeacon is disposed before it emits a value and no fallback is provided.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [] ✨ New feature (non-breaking change which adds functionality)
-   [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
