### PR TITLE
Implement cascading disposal and block writes to disposed beacons

### DIFF
--- a/packages/state_beacon_core/lib/src/beacons/derived.dart
+++ b/packages/state_beacon_core/lib/src/beacons/derived.dart
@@ -106,7 +106,7 @@ class DerivedBeacon<T> extends ReadableBeacon<T> with Consumer {
     for (final source in sources) {
       source!._removeObserver(this);
     }
-    sources.length = 0;
+    sources.clear();
     super.dispose();
   }
 }

--- a/packages/state_beacon_core/lib/src/consumer.dart
+++ b/packages/state_beacon_core/lib/src/consumer.dart
@@ -59,6 +59,13 @@ mixin Consumer {
     }
   }
 
+  void _sourceDisposed(Producer<dynamic> source) {
+    // if one of our sources is disposed, we should dispose ourselves
+    // this is a bit strict because other sources might still be alive
+    // but I want to enforce this to promote good practices
+    Future.microtask(dispose);
+  }
+
   /// Start watching a new source.
   void startWatching(Producer<dynamic> source) {
     if (currentGets.contains(source)) return;
@@ -85,4 +92,7 @@ mixin Consumer {
 
   /// Update the consumer.
   void update();
+
+  /// Dispose the consumer.
+  void dispose();
 }

--- a/packages/state_beacon_core/lib/src/consumers/effect.dart
+++ b/packages/state_beacon_core/lib/src/consumers/effect.dart
@@ -86,8 +86,8 @@ class Effect with Consumer {
   }
 
   /// Disposes the effect.
+  @override
   void dispose() {
-    // print('disposing $name');
     // ignore: avoid_dynamic_calls
     _disposeChild?.call();
     _effectQueue.remove(this);
@@ -95,7 +95,7 @@ class Effect with Consumer {
     for (final source in sources) {
       source!._removeObserver(this);
     }
-    sources.length = 0;
+    sources.clear();
     _disposeChild = null;
   }
 }

--- a/packages/state_beacon_core/lib/src/consumers/subscription.dart
+++ b/packages/state_beacon_core/lib/src/consumers/subscription.dart
@@ -114,6 +114,7 @@ class Subscription<T> implements Consumer {
   }
 
   /// Disposes of the subscription.
+  @override
   void dispose() {
     // Remove this subscription from the producer's observer list.
     producer._removeObserver(this);
@@ -125,6 +126,14 @@ class Subscription<T> implements Consumer {
 
   @override
   void markCheck() => stale(CHECK);
+
+  @override
+  void _sourceDisposed(Producer<dynamic> source) {
+    // if one of our sources is disposed, we should dispose ourselves
+    // this is a bit strict because other sources might still be alive
+    // but I want to enforce this to promote good practices
+    Future.microtask(dispose);
+  }
 
   // these should never be called
   // coverage:ignore-start

--- a/packages/state_beacon_core/lib/src/consumers/subscription.dart
+++ b/packages/state_beacon_core/lib/src/consumers/subscription.dart
@@ -57,7 +57,6 @@ class Subscription<T> implements Consumer {
 
   @override
   void stale(Status newStatus) {
-    // print('$name is stale: $newStatus. current: $_status');
     // If already dirty, no need to update the status
     if (_status == DIRTY) return;
     if (_status < newStatus) {
@@ -72,7 +71,6 @@ class Subscription<T> implements Consumer {
 
   @override
   void updateIfNecessary() {
-    // print('$name will update if necessary  current: $_status');
     if (_status == CLEAN) return;
 
     // Check dependent sources (only for DerivedBeacon)
@@ -82,7 +80,6 @@ class Subscription<T> implements Consumer {
 
     // Update if still dirty
     if (_status == DIRTY) {
-      // print('$name is dirty: updating');
       update();
     }
 

--- a/packages/state_beacon_core/lib/src/mixins/autosleep.dart
+++ b/packages/state_beacon_core/lib/src/mixins/autosleep.dart
@@ -46,6 +46,7 @@ mixin _AutoSleep<T, SubT> on ReadableBeacon<T> {
   void _unsubFromStream() {
     final oldSub = _sub!;
     oldSub.cancel();
+    _sub = null;
   }
 
   @override
@@ -60,8 +61,6 @@ mixin _AutoSleep<T, SubT> on ReadableBeacon<T> {
   void _cancel() {
     _effectDispose?.call();
     _effectDispose = null;
-    // effect dispose will cancel the sub so no need to cancel it here
-    _sub = null;
   }
 
   @override

--- a/packages/state_beacon_core/lib/src/producer.dart
+++ b/packages/state_beacon_core/lib/src/producer.dart
@@ -209,6 +209,9 @@ abstract class Producer<T> {
   /// Clears all registered listeners and
   /// reset the beacon to its initial state.
   void dispose() {
+    for (final observer in _observers) {
+      observer._sourceDisposed(this);
+    }
     _observers.clear();
     // ignore: deprecated_member_use_from_same_package
     widgetSubscribers.clear();

--- a/packages/state_beacon_core/lib/src/producer.dart
+++ b/packages/state_beacon_core/lib/src/producer.dart
@@ -217,7 +217,6 @@ abstract class Producer<T> {
     _observers.clear();
     // ignore: deprecated_member_use_from_same_package
     widgetSubscribers.clear();
-    if (!_isEmpty) _value = _initialValue;
     _previousValue = null;
     for (final callback in _disposeCallbacks) {
       callback();

--- a/packages/state_beacon_core/lib/src/producer.dart
+++ b/packages/state_beacon_core/lib/src/producer.dart
@@ -222,7 +222,6 @@ abstract class Producer<T> {
       callback();
     }
     _disposeCallbacks.clear();
-    // BeaconObserver.instance?.onDispose(this);
   }
 
   @override

--- a/packages/state_beacon_core/lib/src/producer.dart
+++ b/packages/state_beacon_core/lib/src/producer.dart
@@ -141,11 +141,25 @@ abstract class Producer<T> {
   /// when used within a `Beacon.effect` or `Beacon.derived`.
   T get value {
     if (_isEmpty) throw UninitializeLazyReadException(name);
+    assert(() {
+      if (isDisposed) {
+        // coverage:ignore-start
+        // ignore: avoid_print
+        print(
+          '[WARNING]: You read the value of a disposed beacon($name). '
+          'This is not recommended and is probably a bug in your code. '
+          'If you intend to reuse a beacon, try resetting instead of disposing it.',
+        );
+        // coverage:ignore-end
+      }
+      return true;
+    }());
     currentConsumer?.startWatching(this);
     return _value;
   }
 
   void _setValue(T newValue, {bool force = false}) {
+    assert(!_isDisposed, 'Cannot update the value of a disposed beacon.');
     if (_isEmpty) {
       _isEmpty = false;
       _initialValue = newValue;
@@ -179,6 +193,7 @@ abstract class Producer<T> {
     bool startNow = true,
     bool synchronous = false,
   }) {
+    assert(!_isDisposed, 'Cannot subscribe to a disposed beacon.');
     final sub = Subscription(
       this,
       callback,

--- a/packages/state_beacon_core/lib/src/producer.dart
+++ b/packages/state_beacon_core/lib/src/producer.dart
@@ -209,6 +209,8 @@ abstract class Producer<T> {
   /// Clears all registered listeners and
   /// reset the beacon to its initial state.
   void dispose() {
+    if (_isDisposed) return;
+    _isDisposed = true;
     for (final observer in _observers) {
       observer._sourceDisposed(this);
     }
@@ -221,7 +223,6 @@ abstract class Producer<T> {
       callback();
     }
     _disposeCallbacks.clear();
-    _isDisposed = true;
     // BeaconObserver.instance?.onDispose(this);
   }
 

--- a/packages/state_beacon_core/test/src/beacons/future_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/future_test.dart
@@ -820,7 +820,6 @@ void main() {
       expect(f3.unwrapValue(), 30);
       expect(ran, 1);
 
-      // print('\nupdate a\n');
       a.increment();
       BeaconScheduler.flush();
       expect(f3.isLoading, true);
@@ -828,7 +827,6 @@ void main() {
       expect(f3.unwrapValue(), 31);
       expect(ran, 2);
 
-      // print('\nupdate b\n');
       b.increment();
       BeaconScheduler.flush();
       expect(f3.isLoading, true);

--- a/packages/state_beacon_core/test/src/core_test.dart
+++ b/packages/state_beacon_core/test/src/core_test.dart
@@ -693,4 +693,10 @@ void main() {
     expect(d.isDisposed, true);
     expect(e.isDisposed, true);
   });
+
+  test('should throw when writing to disposed beacon', () {
+    final a = Beacon.writable(10);
+    a.dispose();
+    expect(() => a.value = 20, throwsA(isA<AssertionError>()));
+  });
 }

--- a/packages/state_beacon_core/test/src/core_test.dart
+++ b/packages/state_beacon_core/test/src/core_test.dart
@@ -516,4 +516,181 @@ void main() {
 
     expect(ran, 0);
   });
+
+  test('should dispose all observers when disposed/1', () async {
+    // BeaconObserver.instance = LoggingObserver();
+    final a = Beacon.writable(10, name: 'a');
+    final b = Beacon.writable(10, name: 'b');
+    final c = Beacon.derived(() => a.value * b.value, name: 'c');
+
+    a.subscribe((_) {});
+    b.subscribe((_) {});
+
+    Beacon.effect(
+      () {
+        c.value;
+      },
+      name: 'effect',
+    );
+
+    BeaconScheduler.flush();
+
+    expect(a.listenersCount, 2); // sub and derived
+    expect(b.listenersCount, 2); // sub and derived
+    expect(c.listenersCount, 1); // effect
+
+    // this should dispose the sub and derived
+    // when the derived is disposed, it should dispose the effect
+    a.dispose();
+
+    await delay();
+
+    expect(a.listenersCount, 0);
+    expect(b.listenersCount, 1); // sub
+    expect(c.listenersCount, 0);
+    expect(a.isDisposed, true);
+    expect(b.isDisposed, false); // has to be disposed manually
+    expect(c.isDisposed, true);
+  });
+
+  test('should dispose all observers when disposed/2', () async {
+    // BeaconObserver.instance = LoggingObserver();
+    final a = Beacon.writable(10, name: 'a');
+    final b = Beacon.writable(10, name: 'b');
+    final c = Beacon.derived(() => a.value * b.value, name: 'c');
+    final d = Beacon.derived(() => c.value + 1, name: 'd');
+    final e = Beacon.derived(() => d.value + b.value, name: 'e');
+
+    a.subscribe((_) {});
+    b.subscribe((_) {});
+    d.subscribe((_) {});
+    e.subscribe((_) {});
+
+    Beacon.effect(
+      () {
+        c.value;
+      },
+      name: 'effect',
+    );
+
+    BeaconScheduler.flush();
+
+    expect(a.listenersCount, 2); // sub and c
+    expect(b.listenersCount, 3); // sub, c and e
+    expect(c.listenersCount, 2); // effect and d
+    expect(d.listenersCount, 2); // sub and e
+    expect(e.listenersCount, 1); // sub
+
+    // this should dispose the sub and derived
+    // when the derived is disposed, it should dispose the effect
+    a.dispose();
+
+    await delay();
+
+    expect(a.listenersCount, 0);
+    expect(b.listenersCount, 1); // sub
+    expect(c.listenersCount, 0);
+    expect(d.listenersCount, 0);
+    expect(e.listenersCount, 0);
+    expect(a.isDisposed, true);
+    expect(b.isDisposed, false); // has to be disposed manually
+    expect(c.isDisposed, true);
+    expect(d.isDisposed, true);
+    expect(e.isDisposed, true);
+  });
+
+  test('should dispose all observers when disposed/3', () async {
+    // BeaconObserver.instance = LoggingObserver();
+    final a = Beacon.writable(10, name: 'a');
+    final b = Beacon.writable(10, name: 'b');
+    final c = Beacon.derived(() => a.value * b.value, name: 'c');
+    final d = Beacon.derived(() => c.value + 1, name: 'd');
+    final e = Beacon.derived(() => d.value + b.value, name: 'e');
+
+    a.subscribe((_) {});
+    b.subscribe((_) {});
+    d.subscribe((_) {});
+    e.subscribe((_) {});
+
+    Beacon.effect(
+      () {
+        c.value;
+      },
+      name: 'effect',
+    );
+
+    BeaconScheduler.flush();
+
+    expect(a.listenersCount, 2); // sub and c
+    expect(b.listenersCount, 3); // sub, c and e
+    expect(c.listenersCount, 2); // effect and d
+    expect(d.listenersCount, 2); // sub and e
+    expect(e.listenersCount, 1); // sub
+
+    d.dispose();
+
+    await delay();
+
+    expect(a.listenersCount, 2);
+    expect(b.listenersCount, 2); // sub and c
+    expect(c.listenersCount, 1); // effect
+    expect(d.listenersCount, 0);
+    expect(e.listenersCount, 0);
+    expect(a.isDisposed, false);
+    expect(b.isDisposed, false);
+    expect(c.isDisposed, false);
+    expect(d.isDisposed, true);
+    expect(e.isDisposed, true);
+  });
+
+  test('should dispose all observers when disposed/4', () async {
+    // BeaconObserver.instance = LoggingObserver();
+    final a = Beacon.writable(10, name: 'a');
+    final b = Beacon.derived(() => a.value * 2, name: 'b');
+    final c = Beacon.derived(() => a.value * 2, name: 'c');
+    final d = Beacon.derived(() => a.value * 2, name: 'd');
+    final e = Beacon.derived(() => a.value * 2, name: 'e');
+
+    a.subscribe((_) {});
+    a.subscribe((_) {});
+    a.subscribe((_) {});
+    a.subscribe((_) {});
+
+    Beacon.effect(
+      () {
+        a.value;
+      },
+      name: 'effect',
+    );
+
+    b.peek();
+    c.peek();
+    d.peek();
+    e.peek();
+
+    BeaconScheduler.flush();
+
+    expect(a.listenersCount, 9);
+    expect(b.listenersCount, 0);
+    expect(c.listenersCount, 0);
+    expect(d.listenersCount, 0);
+    expect(e.listenersCount, 0);
+
+    // this should dispose the sub and derived
+    // when the derived is disposed, it should dispose the effect
+    a.dispose();
+
+    await delay();
+
+    expect(a.listenersCount, 0);
+    expect(b.listenersCount, 0);
+    expect(c.listenersCount, 0);
+    expect(d.listenersCount, 0);
+    expect(e.listenersCount, 0);
+    expect(a.isDisposed, true);
+    expect(b.isDisposed, true);
+    expect(c.isDisposed, true);
+    expect(d.isDisposed, true);
+    expect(e.isDisposed, true);
+  });
 }

--- a/packages/state_beacon_core/test/src/observer_test.dart
+++ b/packages/state_beacon_core/test/src/observer_test.dart
@@ -63,8 +63,6 @@ void main() {
     BeaconScheduler.flush();
     a.increment();
     BeaconScheduler.flush();
-    a.dispose();
-    BeaconScheduler.flush();
 
     final dispose = Beacon.effect(() {
       if (guard.value) {
@@ -75,7 +73,6 @@ void main() {
 
     expect(_onCreateCalled, 2);
     expect(_onUpdateCalled, 2);
-    expect(_onDisposeCalled, 1);
     expect(_onWatchCalled, 2);
     expect(_lazyOnCreate, isFalse);
 
@@ -105,6 +102,11 @@ void main() {
 
     expect(_onUpdateCalled, 5);
     expect(_onWatchCalled, 5);
+
+    a.dispose();
+    BeaconScheduler.flush();
+
+    expect(_onDisposeCalled, 1);
   });
 
   test('should call onCreate with lazy set as true', () {


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Disposing a beacon indicates that you have no more use for it, therefore, writing to a disposed beacon will not be allowed. Reading a disposed beacon is permitted but a warning will be shown in debug mode.

A major change in how disposal works. When a beacon is disposed. All downstreams derived beacons, effects and subscriptions will be disposed too (even if they are watching other live beacons). This prevents memory leaks.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
