### PR TITLE
Add synchronous option to wrap, buffer, bufferTime, debounce, throttle, filtered, and map methods

### DIFF
--- a/packages/state_beacon_core/lib/src/extensions/chain.dart
+++ b/packages/state_beacon_core/lib/src/extensions/chain.dart
@@ -21,6 +21,7 @@ extension ReadableBeaconWrapUtils<T> on ReadableBeacon<T> {
   BufferedCountBeacon<T> buffer(
     int count, {
     String? name,
+    bool synchronous = true,
   }) {
     assert(
       this is! BufferedBaseBeacon,
@@ -43,7 +44,7 @@ final beacon = Beacon.bufferedCount<T>(count).wrap(someBufferedBeacon)
       name: name,
     );
 
-    _wrapAndDelegate(beacon);
+    _wrapAndDelegate(beacon, synchronous);
 
     return beacon;
   }
@@ -71,6 +72,7 @@ final beacon = Beacon.bufferedCount<T>(count).wrap(someBufferedBeacon)
   BufferedTimeBeacon<T> bufferTime({
     required Duration duration,
     String? name,
+    bool synchronous = true,
   }) {
     assert(
       this is! BufferedBaseBeacon,
@@ -93,7 +95,7 @@ final beacon = Beacon.bufferedCount<T>(count).wrap(someBufferedBeacon)
       name: name,
     );
 
-    _wrapAndDelegate(beacon);
+    _wrapAndDelegate(beacon, synchronous);
 
     return beacon;
   }
@@ -122,6 +124,7 @@ final beacon = Beacon.bufferedCount<T>(count).wrap(someBufferedBeacon)
   DebouncedBeacon<T> debounce({
     required Duration duration,
     String? name,
+    bool synchronous = true,
   }) {
     assert(
       this is! BufferedBaseBeacon,
@@ -144,7 +147,7 @@ final beacon = Beacon.debounced<T>(0).wrap(someBufferedBeacon)
       name: name,
     );
 
-    _wrapAndDelegate(beacon);
+    _wrapAndDelegate(beacon, synchronous);
 
     return beacon;
   }
@@ -167,6 +170,7 @@ final beacon = Beacon.debounced<T>(0).wrap(someBufferedBeacon)
   ThrottledBeacon<T> throttle({
     required Duration duration,
     bool dropBlocked = true,
+    bool synchronous = true,
     String? name,
   }) {
     assert(
@@ -191,7 +195,7 @@ final beacon = Beacon.throttled<T>(0).wrap(someBufferedBeacon)
       name: name,
     );
 
-    _wrapAndDelegate(beacon);
+    _wrapAndDelegate(beacon, synchronous);
 
     return beacon;
   }
@@ -215,6 +219,7 @@ final beacon = Beacon.throttled<T>(0).wrap(someBufferedBeacon)
     bool Function(T?, T) filter, {
     String? name,
     bool lazyBypass = true,
+    bool synchronous = true,
   }) {
     assert(
       this is! BufferedBaseBeacon,
@@ -238,7 +243,7 @@ final beacon = Beacon.filtered<T>(0).wrap(someBufferedBeacon)
       lazyBypass: lazyBypass,
     );
 
-    _wrapAndDelegate(beacon);
+    _wrapAndDelegate(beacon, synchronous);
 
     return beacon;
   }
@@ -262,6 +267,7 @@ final beacon = Beacon.filtered<T>(0).wrap(someBufferedBeacon)
   ReadableBeacon<O> map<O>(
     MapFilter<T, O> mapFN, {
     String? name,
+    bool synchronous = true,
   }) {
     assert(
       this is! BufferedBaseBeacon,
@@ -277,18 +283,20 @@ Bad: someBeacon.buffer(10).map();
 
     final beacon = _MappedBeacon(mapFN, name: name);
 
-    _wrapAndDelegate(beacon);
+    _wrapAndDelegate(beacon, synchronous);
 
     return beacon;
   }
 
   void _wrapAndDelegate<InputT, OutputT>(
     BeaconWrapper<InputT, OutputT> beacon,
+    bool synchronous,
   ) {
     beacon.wrap(
       this,
       disposeTogether: true,
       startNow: !isEmpty,
+      synchronous: synchronous,
     );
 
     // Example 1:

--- a/packages/state_beacon_core/lib/src/extensions/wrap.dart
+++ b/packages/state_beacon_core/lib/src/extensions/wrap.dart
@@ -37,6 +37,7 @@ extension WritableWrap<T, U> on BeaconWrapper<T, U> {
     void Function(V)? then,
     bool disposeTogether = false,
     bool startNow = true,
+    bool synchronous = true,
   }) {
     if (_wrapped.containsKey(target.hashCode)) return;
 
@@ -52,7 +53,11 @@ extension WritableWrap<T, U> on BeaconWrapper<T, U> {
 
     final fn = then ?? ((val) => _onNewValueFromWrapped(val as T));
 
-    final unsub = target.subscribe(fn, startNow: startNow, synchronous: true);
+    final unsub = target.subscribe(
+      fn,
+      startNow: startNow,
+      synchronous: synchronous,
+    );
 
     _wrapped[target.hashCode] = unsub;
 

--- a/packages/state_beacon_core/test/src/extensions/wrap_test.dart
+++ b/packages/state_beacon_core/test/src/extensions/wrap_test.dart
@@ -258,7 +258,7 @@ void main() {
     );
   });
 
-  test('should not autobatch when synchronous=true', () {
+  test('should NOT autobatch when synchronous=true', () {
     final original = Beacon.writable(10);
     final wrapper = Beacon.writable(0);
 

--- a/packages/state_beacon_core/test/src/extensions/wrap_test.dart
+++ b/packages/state_beacon_core/test/src/extensions/wrap_test.dart
@@ -257,4 +257,34 @@ void main() {
       completion([0, 2, 4, 6]),
     );
   });
+
+  test('should not autobatch when synchronous=true', () {
+    final original = Beacon.writable(10);
+    final wrapper = Beacon.writable(0);
+
+    wrapper.wrap(original);
+    expect(wrapper.value, 10);
+
+    original.value = 20;
+    expect(wrapper.value, 20);
+
+    original.value = 30;
+    expect(wrapper.value, 30);
+  });
+
+  test('should autobatch when synchronous=false', () async {
+    final original = Beacon.writable(10);
+    final wrapper = Beacon.writable(0);
+
+    wrapper.wrap(original, synchronous: false);
+    expect(wrapper.value, 0);
+    await expectLater(wrapper.next(), completion(10));
+
+    original.value = 20;
+    original.value = 30;
+    original.value = 40;
+    original.value = 50;
+    expect(wrapper.value, 10); // should not update immediately
+    await expectLater(wrapper.next(), completion(50));
+  });
 }


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

Wrapping was synchronous by default which also disabled auto-batching. This PR adds a the ability to customize this.

```dart
  test('should NOT autobatch when synchronous=true', () {
    final original = Beacon.writable(10);
    final wrapper = Beacon.writable(0);

    wrapper.wrap(original);
    expect(wrapper.value, 10);

    original.value = 20;
    expect(wrapper.value, 20);

    original.value = 30;
    expect(wrapper.value, 30);
  });

  test('should autobatch when synchronous=false', () async {
    final original = Beacon.writable(10);
    final wrapper = Beacon.writable(0);

    wrapper.wrap(original, synchronous: false);
    expect(wrapper.value, 0);
    await expectLater(wrapper.next(), completion(10));

    original.value = 20;
    original.value = 30;
    original.value = 40;
    original.value = 50;
    expect(wrapper.value, 10); // should not update immediately
    await expectLater(wrapper.next(), completion(50));
  });
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
