### PR TITLE
Add BeaconController

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1169,6 +1169,65 @@ count.value = 30;
 count.value = 40;
 ```
 
+## BeaconController
+
+An abstract mixin class that automatically disposes all beacons and effects created within it. This can be used to create a controller that manages a group of beacons.
+
+NB: All beacons must be created with as a `late` variable and with the local BeaconCreator `B` instead of `Beacon`.
+
+```dart
+class CountController extends BeaconController {
+  late final count = B.writable(0);
+  late final doubledCount = B.derived(() => count.value * 2);
+}
+```
+
+This can be used with the [lite_ref](https://pub.dev/packages/lite_ref) or Provider package to provide the controller to widgets. lite_ref will dispose the controller when all widgets that use it are disposed.
+
+In the example below, the controller will be disposed when the `CounterText` is unmounted:
+
+```dart
+final countControllerRef = Ref.scoped((ctx) => CountController());
+
+class CounterText extends StatelessWidget {
+  const CounterText({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = countControllerRef.of(context);
+    final count = controller.count.watch(context);
+    return Text('$count');
+  }
+}
+```
+
+See the full example [here](https://github.com/jinyus/dart_beacon/blob/main/examples/counter/lib/main.dart).
+
+### BeaconControllerMixin
+
+A mixin for `StatefulWidget`'s `State` class that automatically disposes all beacons and effects created within it.
+
+```dart
+class MyController extends StatefulWidget {
+  const MyController({super.key});
+
+  @override
+  State<MyController> createState() => _MyControllerState();
+}
+
+class _MyControllerState extends State<MyController>
+    with BeaconControllerMixin {
+  // NO need to dispose these manually
+  late final count = B.writable(0);
+  late final doubledCount = B.derived(() => count.value * 2);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}
+```
+
 ## Pitfalls
 
 When using `Beacon.future`, only beacons accessed before the async gap(`await`) will be tracked as dependencies.

--- a/examples/auth_flow/pubspec.lock
+++ b/examples/auth_flow/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  basic_interfaces:
+    dependency: transitive
+    description:
+      name: basic_interfaces
+      sha256: c37c8c4ddbc594430eb3817a4edfcc9a0cadbc7ea4c51a5b48785e351f1ba479
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -192,10 +200,10 @@ packages:
     dependency: transitive
     description:
       name: state_beacon_core
-      sha256: "6c3a36e15c4be2e3c21a07b38b1647869b28b84920b80bdc2f34f782dcb0cbf4"
+      sha256: "774b9ba884fa2a56be7e705fc3ba4ce0d6e391078e4c8c5213ce4fda9fed8df9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.39.1"
+    version: "0.40.0"
   stream_channel:
     dependency: transitive
     description:

--- a/examples/counter/lib/main.dart
+++ b/examples/counter/lib/main.dart
@@ -2,8 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:lite_ref/lite_ref.dart';
 import 'package:state_beacon/state_beacon.dart';
 
-class Controller {
-  late final _count = Beacon.writable(0);
+class Controller extends BeaconController {
+  late final _count = B.writable(0);
 
   // we expose it as a readable beacon
   // so it cannot be changed from outside the controller.

--- a/examples/counter/pubspec.lock
+++ b/examples/counter/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  basic_interfaces:
+    dependency: transitive
+    description:
+      name: basic_interfaces
+      sha256: c37c8c4ddbc594430eb3817a4edfcc9a0cadbc7ea4c51a5b48785e351f1ba479
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -163,10 +171,10 @@ packages:
     dependency: transitive
     description:
       name: state_beacon_core
-      sha256: "6c3a36e15c4be2e3c21a07b38b1647869b28b84920b80bdc2f34f782dcb0cbf4"
+      sha256: "774b9ba884fa2a56be7e705fc3ba4ce0d6e391078e4c8c5213ce4fda9fed8df9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.39.1"
+    version: "0.40.0"
   stream_channel:
     dependency: transitive
     description:

--- a/examples/flutter_main/pubspec.lock
+++ b/examples/flutter_main/pubspec.lock
@@ -41,6 +41,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  basic_interfaces:
+    dependency: transitive
+    description:
+      name: basic_interfaces
+      sha256: c37c8c4ddbc594430eb3817a4edfcc9a0cadbc7ea4c51a5b48785e351f1ba479
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -395,10 +403,10 @@ packages:
     dependency: transitive
     description:
       name: state_beacon_core
-      sha256: "6c3a36e15c4be2e3c21a07b38b1647869b28b84920b80bdc2f34f782dcb0cbf4"
+      sha256: "774b9ba884fa2a56be7e705fc3ba4ce0d6e391078e4c8c5213ce4fda9fed8df9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.39.1"
+    version: "0.40.0"
   state_beacon_lint:
     dependency: "direct dev"
     description:

--- a/examples/shopping_cart/pubspec.lock
+++ b/examples/shopping_cart/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  basic_interfaces:
+    dependency: transitive
+    description:
+      name: basic_interfaces
+      sha256: c37c8c4ddbc594430eb3817a4edfcc9a0cadbc7ea4c51a5b48785e351f1ba479
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -200,10 +208,10 @@ packages:
     dependency: transitive
     description:
       name: state_beacon_core
-      sha256: "6c3a36e15c4be2e3c21a07b38b1647869b28b84920b80bdc2f34f782dcb0cbf4"
+      sha256: "774b9ba884fa2a56be7e705fc3ba4ce0d6e391078e4c8c5213ce4fda9fed8df9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.39.1"
+    version: "0.40.0"
   stream_channel:
     dependency: transitive
     description:

--- a/examples/skeleton/pubspec.lock
+++ b/examples/skeleton/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  basic_interfaces:
+    dependency: transitive
+    description:
+      name: basic_interfaces
+      sha256: c37c8c4ddbc594430eb3817a4edfcc9a0cadbc7ea4c51a5b48785e351f1ba479
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -176,10 +184,10 @@ packages:
     dependency: transitive
     description:
       name: state_beacon_core
-      sha256: "6c3a36e15c4be2e3c21a07b38b1647869b28b84920b80bdc2f34f782dcb0cbf4"
+      sha256: "774b9ba884fa2a56be7e705fc3ba4ce0d6e391078e4c8c5213ce4fda9fed8df9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.39.1"
+    version: "0.40.0"
   stream_channel:
     dependency: transitive
     description:

--- a/examples/vgv_best_practices/pubspec.lock
+++ b/examples/vgv_best_practices/pubspec.lock
@@ -9,6 +9,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.11.0"
+  basic_interfaces:
+    dependency: transitive
+    description:
+      name: basic_interfaces
+      sha256: c37c8c4ddbc594430eb3817a4edfcc9a0cadbc7ea4c51a5b48785e351f1ba479
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   boolean_selector:
     dependency: transitive
     description:
@@ -184,10 +192,10 @@ packages:
     dependency: transitive
     description:
       name: state_beacon_core
-      sha256: "6c3a36e15c4be2e3c21a07b38b1647869b28b84920b80bdc2f34f782dcb0cbf4"
+      sha256: "774b9ba884fa2a56be7e705fc3ba4ce0d6e391078e4c8c5213ce4fda9fed8df9"
       url: "https://pub.dev"
     source: hosted
-    version: "0.39.1"
+    version: "0.40.0"
   stream_channel:
     dependency: transitive
     description:

--- a/packages/state_beacon/README.md
+++ b/packages/state_beacon/README.md
@@ -141,6 +141,7 @@ NB: Create the file if it doesn't exist.
         -   [debounce](#mybeacondebounce): Returns a [Beacon.debounced](#beacondebounced) that wraps this beacon.
 -   [Debugging](#debugging): Facilities for debugging and observing beacons.
 -   [Disposal](#disposal): Disposing beacons and effects.
+-   [Testing](#testing): How to test beacons.
 
 [Pitfalls](#pitfalls)
 
@@ -1112,6 +1113,60 @@ a.dispose();
 expect(a.isDisposed, true);
 expect(c.isDisposed, true);
 // effect is also disposed
+```
+
+## Testing
+
+Beacons can expose a `Stream` with the `.stream` getter. This can be used to test the state of a beacon over time with existing `StreamMatcher`s.
+
+```dart
+final count = Beacon.writable(10);
+
+final stream = count.stream;
+
+Future.delayed(Duration(milliseconds: 1), () => count.value = 20);
+
+expect(stream, emitsInOrder([10, 20]));
+```
+
+### Testing beacons with chaining methods
+
+[Chaining](#chaining-methods) methods (`buffer`, `bufferTime`, `next`) can be used to make testing easier.
+
+##### anyBeacon.buffer()
+
+```dart
+final count = Beacon.writable(10);
+
+final buff = count.buffer(2);
+
+count.value = 20;
+
+expect(buff.value, equals([10, 20]));
+```
+
+##### anyBeacon.next()
+
+```dart
+final count = Beacon.writable(10);
+
+expectLater(count.next(), completion(30));
+
+count.value = 30;
+```
+
+##### anyBeacon.bufferTime().next()
+
+```dart
+final count = Beacon.writable(10);
+
+final buffTime = count.bufferTime(duration: Duration(milliseconds: 10));
+
+expectLater(buffTime.next(), completion([10, 20, 30, 40]));
+
+count.value = 20;
+count.value = 30;
+count.value = 40;
 ```
 
 ## Pitfalls

--- a/packages/state_beacon/lib/src/controller/controller.dart
+++ b/packages/state_beacon/lib/src/controller/controller.dart
@@ -1,0 +1,50 @@
+// ignore_for_file: non_constant_identifier_names
+
+import 'package:flutter/widgets.dart';
+import 'package:state_beacon/state_beacon.dart';
+
+/// An abstract mixin class that automatically disposes all beacons created by
+/// this controller.
+abstract mixin class BeaconController implements Disposable {
+  /// Local BeaconCreator that automatically
+  /// disposes all beacons created by this controller.
+  ///
+  /// ### All beacons must be created with as a `late` variable.
+  /// ```dart
+  /// late final age = B.writable(50);
+  ///  ^
+  ///  |
+  /// this is required
+  /// ```
+  final B = BeaconGroup();
+
+  /// Disposes all beacons created by this controller.
+  @override
+  @mustCallSuper
+  void dispose() {
+    B.disposeAll();
+  }
+}
+
+/// A mixin that automatically disposes all beacons created by this Widget.
+mixin BeaconControllerMixin<T extends StatefulWidget> on State<T> {
+  /// Local BeaconCreator that automatically
+  /// disposes all beacons created within this State class.
+  ///
+  /// ### All beacons must be created with as a `late` variable.
+  /// ```dart
+  /// late final age = B.writable(50);
+  ///  ^
+  ///  |
+  /// this is required
+  /// ```
+  final B = BeaconGroup();
+
+  /// Disposes all beacons created by this controller.
+  @override
+  @mustCallSuper
+  void dispose() {
+    B.disposeAll();
+    super.dispose();
+  }
+}

--- a/packages/state_beacon/lib/src/extensions/watch_observe.dart
+++ b/packages/state_beacon/lib/src/extensions/watch_observe.dart
@@ -85,11 +85,11 @@ extension WidgetUtils<T> on BaseBeacon<T> {
     BuildContext context, {
     VoidCallback? callback,
   }) {
-    if (widgetSubscribers.contains(key)) {
+    if ($$widgetSubscribers$$.contains(key)) {
       return peek();
     }
 
-    widgetSubscribers.add(key);
+    $$widgetSubscribers$$.add(key);
 
     final elementRef = WeakReference(context as Element);
     late VoidCallback unsub;
@@ -109,7 +109,7 @@ extension WidgetUtils<T> on BaseBeacon<T> {
         run();
       } else {
         unsub();
-        widgetSubscribers.remove(key);
+        $$widgetSubscribers$$.remove(key);
         cancel();
       }
     }
@@ -122,7 +122,7 @@ extension WidgetUtils<T> on BaseBeacon<T> {
     _finalizer.attach(
       context,
       () {
-        widgetSubscribers.remove(key);
+        $$widgetSubscribers$$.remove(key);
         unsub();
         cancel();
       },

--- a/packages/state_beacon/lib/state_beacon.dart
+++ b/packages/state_beacon/lib/state_beacon.dart
@@ -3,6 +3,8 @@ library;
 
 export 'package:state_beacon_core/state_beacon_core.dart' hide BeaconScheduler;
 
+export 'src/controller/controller.dart';
+
 export 'src/extensions/extensions.dart' hide hasNotifier;
 
 export 'src/scheduler.dart';

--- a/packages/state_beacon/pubspec.yaml
+++ b/packages/state_beacon/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
     flutter:
         sdk: flutter
-    state_beacon_core: ^0.39.1
+    state_beacon_core: ^0.40.0
 
 dev_dependencies:
     flutter_lints: ^3.0.0

--- a/packages/state_beacon/test/src/controller/controller_test.dart
+++ b/packages/state_beacon/test/src/controller/controller_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:state_beacon/state_beacon.dart';
+
+class MyController extends BeaconController {
+  late final count = B.writable(0);
+  late final doubledCount = B.derived(() => count.value * 2);
+}
+
+void main() {
+  test('should dispose all beacons created in controller', () {
+    final controller = MyController();
+    expect(controller.count.isDisposed, false);
+    expect(controller.doubledCount.isDisposed, false);
+
+    controller.dispose();
+
+    expect(controller.count.isDisposed, true);
+    expect(controller.doubledCount.isDisposed, true);
+  });
+
+  testWidgets('should dispose all beacons in State class', (tester) async {
+    await tester.pumpWidget(const CoounterView());
+    final state = tester.state<_CoounterViewState>(find.byType(CoounterView));
+
+    expect(state.count.isDisposed, false);
+    expect(state.doubledCount.isDisposed, false);
+
+    await tester.pumpWidget(const SizedBox.shrink());
+
+    expect(state.count.isDisposed, true);
+    expect(state.doubledCount.isDisposed, true);
+  });
+}
+
+class CoounterView extends StatefulWidget {
+  const CoounterView({super.key});
+
+  @override
+  State<CoounterView> createState() => _CoounterViewState();
+}
+
+class _CoounterViewState extends State<CoounterView>
+    with BeaconControllerMixin {
+  late final count = B.writable(0);
+  late final doubledCount = B.derived(() => count.value * 2);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container();
+  }
+}

--- a/run.sh
+++ b/run.sh
@@ -22,9 +22,12 @@ test_target() {
     elif [ "$1" == "example" ]; then
         echo "testing flutter_main example"
         cd examples/flutter_main &&
-            flutter test
-        echo "testing shopping_cart example"
-        cd ../shopping_cart &&
+            flutter test &&
+            echo "testing shopping_cart example" &&
+            cd ../shopping_cart &&
+            flutter test &&
+            echo "testing counter example" &&
+            cd ../counter &&
             flutter test
     elif [ "$1" == "all" ]; then
         test_target "core" &&


### PR DESCRIPTION
<!--
  Thanks for contributing!

  Provide a description of your changes below and a general summary in the title

  Please look at the following checklist to ensure that your PR can be accepted quickly:
-->

## Description

## BeaconController

An abstract mixin class that automatically disposes all beacons and effects created within it. This can be used to create a controller that manages a group of beacons.

NB: All beacons must be created with as a `late` variable and with the local BeaconCreator `B` instead of `Beacon`.

```dart
class CountController extends BeaconController {
  late final count = B.writable(0);
  late final doubledCount = B.derived(() => count.value * 2);
}
```

This can be used with the [lite_ref](https://pub.dev/packages/lite_ref) or Provider package to provide the controller to widgets. lite_ref will dispose the controller when all widgets that use it are disposed.

In the example below, the controller will be disposed when the `CounterText` is unmounted:

```dart
final countControllerRef = Ref.scoped((ctx) => CountController());

class CounterText extends StatelessWidget {
  const CounterText({super.key});

  @override
  Widget build(BuildContext context) {
    final controller = countControllerRef.of(context);
    final count = controller.count.watch(context);
    return Text('$count');
  }
}
```

See the full example [here](https://github.com/jinyus/dart_beacon/blob/main/examples/counter/lib/main.dart).

### BeaconControllerMixin

A mixin for `StatefulWidget`'s `State` class that automatically disposes all beacons and effects created within it.

```dart
class MyController extends StatefulWidget {
  const MyController({super.key});

  @override
  State<MyController> createState() => _MyControllerState();
}

class _MyControllerState extends State<MyController>
    with BeaconControllerMixin {
  // NO need to dispose these manually
  late final count = B.writable(0);
  late final doubledCount = B.derived(() => count.value * 2);

  @override
  Widget build(BuildContext context) {
    return Container();
  }
}
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
