### PR TITLE
[Fix] More efficient fix for #110

### DIFF
--- a/packages/state_beacon_core/lib/src/consumers/subscription.dart
+++ b/packages/state_beacon_core/lib/src/consumers/subscription.dart
@@ -13,7 +13,11 @@ class Subscription<T> implements Consumer {
   }) {
     // derived beacons are lazy so they aren't registered as observers
     // of their sources until they are actually used
-    if (startNow || _derivedSource?.isEmpty == true) {
+    // If the derived beacon is already initialized and has no observers,
+    // we need to schedule to ensure it gets registered properly
+    if (startNow ||
+        _derivedSource?.isEmpty == true ||
+        (_derivedSource != null && _derivedSource!._observers.isEmpty)) {
       _schedule();
     } else {
       _status = CLEAN;

--- a/packages/state_beacon_core/lib/src/consumers/subscription.dart
+++ b/packages/state_beacon_core/lib/src/consumers/subscription.dart
@@ -43,21 +43,8 @@ class Subscription<T> implements Consumer {
   @override
   List<Producer<dynamic>?> sources = [];
 
-  var _innerStatus = DIRTY;
-
   @override
-  set _status(Status newStatus) {
-    final toRun = _innerStatus == CLEAN &&
-        newStatus == DIRTY &&
-        !_effectQueue.contains(this);
-    _innerStatus = newStatus;
-    if (toRun) {
-      _schedule();
-    }
-  }
-
-  @override
-  Status get _status => _innerStatus;
+  Status _status = DIRTY;
 
   void _schedule() {
     if (synchronous) {


### PR DESCRIPTION
## Description
If the derived beacon is already initialized and has no observers, we need to schedule to ensure it gets registered properly. 

This bug is only present it flutter due to a race condition.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
