### PR TITLE
Fix: use identityHashCode for context

### DIFF
--- a/packages/state_beacon_flutter/lib/src/extensions/watch_observe.dart
+++ b/packages/state_beacon_flutter/lib/src/extensions/watch_observe.dart
@@ -32,7 +32,7 @@ extension WidgetUtils<T> on BaseBeacon<T> {
   ///}
   /// ```
   T watch(BuildContext context) {
-    final key = context.hashCode;
+    final key = identityHashCode(context);
 
     return _watchOrObserve(
       key,

--- a/packages/state_beacon_flutter/lib/src/extensions/watch_observe.dart
+++ b/packages/state_beacon_flutter/lib/src/extensions/watch_observe.dart
@@ -67,7 +67,7 @@ extension WidgetUtils<T> on BaseBeacon<T> {
     bool synchronous = false,
   }) {
     final key = Object.hash(
-      context,
+      identityHashCode(context),
       'isObserving', // create 1 subscription for each widget
     );
 

--- a/packages/state_beacon_flutter/test/src/navigation_bug_test.dart
+++ b/packages/state_beacon_flutter/test/src/navigation_bug_test.dart
@@ -1,0 +1,361 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:state_beacon_flutter/state_beacon_flutter.dart';
+
+void main() {
+  BeaconScheduler.useFlutterScheduler();
+
+  testWidgets(
+    'watch with forced hashCode collision demonstrates bug',
+    (WidgetTester tester) async {
+      final counter = Beacon.writable(0);
+      const collisionHash = 999999;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _CollisionWidget(
+            counter: counter,
+            forcedHash: collisionHash,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Count: 0'), findsOneWidget);
+
+      counter.value = 1;
+      await tester.pumpAndSettle();
+      expect(find.text('Count: 1'), findsOneWidget);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: Text('Away')),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Away'), findsOneWidget);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _CollisionWidget(
+            counter: counter,
+            forcedHash: collisionHash,
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Count: 1'), findsOneWidget);
+
+      counter.value = 2;
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text('Count: 2'),
+        findsOneWidget,
+        reason: 'Widget should rebuild when beacon changes after re-navigation',
+      );
+    },
+  );
+
+  testWidgets(
+    'context hashCode investigation',
+    (WidgetTester tester) async {
+      final counter = Beacon.writable(0);
+      BuildContext? firstContext;
+      BuildContext? secondContext;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              firstContext = context;
+              final count = counter.watch(context);
+              return Scaffold(body: Text('First: $count'));
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      counter.value = 1;
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: Text('Away')),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              secondContext = context;
+              final count = counter.watch(context);
+              return Scaffold(body: Text('Second: $count'));
+            },
+          ),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // debugPrint(
+      //   'First - hash: ${firstContext?.hashCode}, '
+      //   'identity: ${identityHashCode(firstContext)}',
+      // );
+      // debugPrint(
+      //   'Second - hash: ${secondContext?.hashCode}, '
+      //   'identity: ${identityHashCode(secondContext)}',
+      // );
+      // debugPrint(
+      //   'HashCodes equal: ${firstContext?.hashCode == secondContext?.hashCode}',
+      // );
+
+      counter.value = 2;
+      await tester.pumpAndSettle();
+
+      expect(find.text('Second: 2'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'watch should rebuild after simulated navigation (Element reuse)',
+    (WidgetTester tester) async {
+      final counter = Beacon.writable(0);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _TestPage(counter: counter, key: const Key('page1')),
+        ),
+      );
+
+      expect(find.text('Count: 0'), findsOneWidget);
+
+      counter.value = 1;
+      await tester.pumpAndSettle();
+      expect(find.text('Count: 1'), findsOneWidget);
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(body: Text('Different Page')),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Different Page'), findsOneWidget);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _TestPage(counter: counter, key: const Key('page2')),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Count: 1'), findsOneWidget);
+
+      counter.value = 2;
+      await tester.pumpAndSettle();
+
+      expect(find.text('Count: 2'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'watch should handle rapid navigation back and forth',
+    (WidgetTester tester) async {
+      final counter = Beacon.writable(0);
+
+      for (var i = 0; i < 5; i++) {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: _TestPage(counter: counter, key: Key('page$i')),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+        expect(find.text('Count: $i'), findsOneWidget);
+
+        counter.value = i + 1;
+        await tester.pumpAndSettle();
+        expect(find.text('Count: ${i + 1}'), findsOneWidget);
+
+        await tester.pumpWidget(
+          const MaterialApp(
+            home: Scaffold(body: Text('Away')),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+      }
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _TestPage(counter: counter, key: const Key('final')),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Count: 5'), findsOneWidget);
+
+      counter.value = 99;
+      await tester.pumpAndSettle();
+
+      expect(find.text('Count: 99'), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'watch should work with hashCode collisions',
+    (WidgetTester tester) async {
+      final counter = Beacon.writable(0);
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: _CollisionTestPage(counter: counter),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      counter.value = 1;
+      await tester.pumpAndSettle();
+
+      final text1Finder = find.text('Widget1: 1');
+      final text2Finder = find.text('Widget2: 1');
+
+      expect(text1Finder, findsOneWidget);
+      expect(text2Finder, findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'watch should handle navigation with route transitions',
+    (WidgetTester tester) async {
+      final counter = Beacon.writable(0);
+      final navigatorKey = GlobalKey<NavigatorState>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          navigatorKey: navigatorKey,
+          home: _TestPage(counter: counter),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Count: 0'), findsOneWidget);
+
+      counter.value = 1;
+      await tester.pumpAndSettle();
+      expect(find.text('Count: 1'), findsOneWidget);
+
+      navigatorKey.currentState!.push(
+        MaterialPageRoute<void>(
+          builder: (_) => const Scaffold(body: Text('Second Page')),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.text('Second Page'), findsOneWidget);
+
+      navigatorKey.currentState!.pop();
+      await tester.pumpAndSettle();
+
+      expect(find.text('Count: 1'), findsOneWidget);
+
+      counter.value = 2;
+      await tester.pumpAndSettle();
+
+      expect(find.text('Count: 2'), findsOneWidget);
+    },
+  );
+}
+
+class _CollisionWidget extends StatefulWidget {
+  const _CollisionWidget({
+    required this.counter,
+    required this.forcedHash,
+  });
+
+  final WritableBeacon<int> counter;
+  final int forcedHash;
+
+  @override
+  State<_CollisionWidget> createState() => _CollisionWidgetStateWithHash();
+
+  @override
+  StatefulElement createElement() => _CollisionElement(this);
+}
+
+class _CollisionElement extends StatefulElement {
+  _CollisionElement(super.widget);
+
+  @override
+  int get hashCode => (widget as _CollisionWidget).forcedHash;
+}
+
+class _CollisionWidgetStateWithHash extends State<_CollisionWidget> {
+  @override
+  Widget build(BuildContext context) {
+    final count = widget.counter.watch(context);
+    return Scaffold(
+      body: Center(
+        child: Text('Count: $count'),
+      ),
+    );
+  }
+}
+
+class _TestPage extends StatelessWidget {
+  const _TestPage({required this.counter, super.key});
+
+  final WritableBeacon<int> counter;
+
+  @override
+  Widget build(BuildContext context) {
+    final count = counter.watch(context);
+    return Scaffold(
+      body: Center(
+        child: Text('Count: $count'),
+      ),
+    );
+  }
+}
+
+class _CollisionTestPage extends StatelessWidget {
+  const _CollisionTestPage({required this.counter});
+
+  final WritableBeacon<int> counter;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+          _WidgetWithHashCode(counter: counter, id: 1),
+          _WidgetWithHashCode(counter: counter, id: 2),
+        ],
+      ),
+    );
+  }
+}
+
+class _WidgetWithHashCode extends StatelessWidget {
+  const _WidgetWithHashCode({
+    required this.counter,
+    required this.id,
+  });
+
+  final WritableBeacon<int> counter;
+  final int id;
+
+  @override
+  Widget build(BuildContext context) {
+    final count = counter.watch(context);
+    return Text('Widget$id: $count');
+  }
+}


### PR DESCRIPTION
## Description

This fixes a bug where go_router could possibly reuse Element instances across navigation; this caused a hash collision as the "new" element would have the same hashcode even though the widget is different. 

This fixes #127 

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
