### PR TITLE
Add updateWith to FutureBeacon

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -363,6 +363,24 @@ All these methods with the exception on `reset()` and `overrideWith()` are also 
 -   `unwrapValueOrNull()`: This is like `unwrapValue()` but it returns null if the beacon is not in the `data` state.
 -   `toFuture()`: Returns a future that completes with the value when the beacon is in the `data` state. This will throw an error if the beacon is not in the `data` state.
 -   `overrideWith()`: Replaces the current callback and resets the beacon by running the new callback.
+-   `updateWith()`: Updates the beacon with the result of the provided future callback.
+
+The `updateWith` method allows you to update a FutureBeacon's value with the provided callback. This differs from `overrideWith` because it updates the value only once, while `overrideWith` replaces the original callback supplied to the beacon.
+
+```dart
+Future<List<Todo>> loadTodos() async { ... }
+
+Future<List<Todo>> addTodo(Todo newTodo) async {
+  await todoService.addTodo(newTodo);
+  final currentTodos = todoBeacon.peek();
+  return [newTodo, ...currentTodos];
+}
+
+final todosBeacon = Beacon.future(() => loadTodos());
+
+// Later, add a new todo without refetching all todos
+await todosBeacon.updateWith(() => addTodo(newTodo));
+```
 
 ### Beacon.stream:
 


### PR DESCRIPTION
## Description
                                                                                                                                                                                                                                               
The `updateWith` method allows you to update a FutureBeacon's value with the provided callback. This differs from `overrideWith` because it updates the value only once, while `overrideWith` replaces the original callback supplied to the beacon.

## Basic Usage

```dart
Future<List<Todo>> loadTodos() async { ... }                                                                                          
                                                                                                                                        
Future<List<Todo>> addTodo(Todo newTodo) async {
  await todoService.addTodo(newTodo);
  final currentTodos = todosBeacon.lastData ?? [];  
  return [newTodo, ...currentTodos];
}   
                                                                                                                                        
final todosBeacon = Beacon.future(() => loadTodos());                                                                                 
                                                                                                                                        
// Later, add a new todo without refetching all todos                                                                                 
await todosBeacon.updateWith(() => addTodo(newTodo));  

// You can also provide an optimistic result
final optimisticTodos = [newTodo, ...todosBeacon.lastData ?? []];
await todosBeacon.updateWith(
  () => addTodo(newTodo),
  optimisticResult: optimisticTodos,
);
```

## Priority Behavior

When multiple computations are in progress, updateWith follows these priority rules:

### 1. Latest updateWith Takes Priority

If multiple updateWith calls are made, only the result of the most recent one is used:

### 2. updateWith Overrides In-Flight Initial Computation

When updateWith is called while the initial beacon computation is still loading, the updateWith result takes priority:

### 3. Dependency Changes Cancel updateWith

If a beacon's dependency changes while updateWith is running, the dependency-triggered computation takes priority and the updateWith result is discarded:

### 4. Setting to Idle Cancels updateWith

If the beacon is manually set to idle (via .idle()) while updateWith is running, the beacon remains idle and the updateWith result is ignored:  


## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
