### PR TITLE
Implement FIFO queue for updateWith calls

### DIFF
--- a/packages/state_beacon/CHANGELOG.md
+++ b/packages/state_beacon/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.0
+
+-   [Feat] Add queuing to FutureBeacon.updateWith()
+    The `updateWith` method calls are now queued when there is an ongoing update. This ensures that all calls are executed in the order they were made, preventing race conditions and inconsistent state.
+
 # 1.2.0
 
 -   [Feat] Add `Future.updateWith()`

--- a/packages/state_beacon_core/CHANGELOG.md
+++ b/packages/state_beacon_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.0
+
+-   [Feat] Add queuing to FutureBeacon.updateWith()
+    The `updateWith` method calls are now queued when there is an ongoing update. This ensures that all calls are executed in the order they were made, preventing race conditions and inconsistent state.
+
 # 1.2.0
 
 -   [Feat] Add `Future.updateWith()`

--- a/packages/state_beacon_core/test/src/beacons/family_test.dart
+++ b/packages/state_beacon_core/test/src/beacons/family_test.dart
@@ -33,7 +33,7 @@ void main() {
 
     expect(doubled.isLoading, true);
 
-    await delay();
+    await doubled.next();
 
     expect(doubled.value.unwrap(), '20');
 

--- a/packages/state_beacon_flutter/CHANGELOG.md
+++ b/packages/state_beacon_flutter/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.0
+
+-   [Feat] Add queuing to FutureBeacon.updateWith()
+    The `updateWith` method calls are now queued when there is an ongoing update. This ensures that all calls are executed in the order they were made, preventing race conditions and inconsistent state.
+
 # 1.2.0
 
 -   [Feat] Add `Future.updateWith()`


### PR DESCRIPTION
## Description
Introduce a queue mechanism for handling multiple `updateWith` calls, ensuring they execute in FIFO order. This change addresses issues with concurrent updates and improves the reliability of state management in the beacon.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore

