### PR TITLE
Deprecate supportConditional parameter in effect methods

### DIFF
--- a/packages/state_beacon_core/lib/src/creator/beacon_creator.dart
+++ b/packages/state_beacon_core/lib/src/creator/beacon_creator.dart
@@ -445,9 +445,6 @@ class _BeaconCreator {
   /// It will cancel the stream subscription and enter a sleep state.
   /// It will resume executing once a listener is added or its value is accessed.
   ///
-  /// If `supportConditional` is `false`(default: true), it will only look dependencies on its first run.
-  /// This means once a beacon is added as a dependency, it will not be removed even if it's no longer used and no new dependencies will be added. This can be used as a performance optimization.
-  ///
   /// Example:
   /// ```dart
   /// final userID = Beacon.writable<int>(18235);
@@ -624,11 +621,6 @@ class _BeaconCreator {
   /// Creates an effect based on a provided function. The provided function will be called
   /// whenever one of its dependencies change.
   ///
-  /// If `supportConditional` is `false`, the effect look for its dependencies on its first run only.
-  /// This means once a beacon is added as a dependency, it will not be removed even if it's no longer used
-  /// and any beacon not accessed in the first run will not be tracked.
-  /// Defaults to `true`.
-  ///
   /// Example:
   /// ```dart
   /// final age = Beacon.writable(15);
@@ -647,6 +639,9 @@ class _BeaconCreator {
   /// ```
   VoidCallback effect(
     Function fn, {
+    @Deprecated(
+      'The supportConditional parameter is no longer needed and will be removed in the next major version.',
+    )
     bool supportConditional = true,
     String? name,
   }) {

--- a/packages/state_beacon_core/lib/src/creator/beacon_group_creator.dart
+++ b/packages/state_beacon_core/lib/src/creator/beacon_group_creator.dart
@@ -107,11 +107,14 @@ class BeaconGroup extends _BeaconCreator {
   @override
   VoidCallback effect(
     Function fn, {
+    @Deprecated(
+      'The supportConditional parameter is no longer needed and '
+      'will be removed in the next major version.',
+    )
     bool supportConditional = true,
     String? name,
   }) {
-    final callback =
-        super.effect(fn, supportConditional: supportConditional, name: name);
+    final callback = super.effect(fn, name: name);
     _disposeFns.add(callback);
     return callback;
   }


### PR DESCRIPTION
Remove the `supportConditional` parameter from effect methods as it is no longer needed. Mark it as deprecated for future removal in the next major version. 
## Description

The `supportConditional` parameter has been deprecated in effect methods, simplifying the API and preparing for its removal in the next major version.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore

