### PR TITLE
Prevent immediate callback invocation for subscriptions with startNow=false

### DIFF
--- a/packages/state_beacon_flutter/test/src/navigation_bug_test.dart
+++ b/packages/state_beacon_flutter/test/src/navigation_bug_test.dart
@@ -236,47 +236,6 @@ void main() {
       expect(text2Finder, findsOneWidget);
     },
   );
-
-  testWidgets(
-    'watch should handle navigation with route transitions',
-    (WidgetTester tester) async {
-      final counter = Beacon.writable(0);
-      final navigatorKey = GlobalKey<NavigatorState>();
-
-      await tester.pumpWidget(
-        MaterialApp(
-          navigatorKey: navigatorKey,
-          home: _TestPage(counter: counter),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-      expect(find.text('Count: 0'), findsOneWidget);
-
-      counter.value = 1;
-      await tester.pumpAndSettle();
-      expect(find.text('Count: 1'), findsOneWidget);
-
-      await navigatorKey.currentState!.push(
-        MaterialPageRoute<void>(
-          builder: (_) => const Scaffold(body: Text('Second Page')),
-        ),
-      );
-
-      await tester.pumpAndSettle();
-      expect(find.text('Second Page'), findsOneWidget);
-
-      navigatorKey.currentState!.pop();
-      await tester.pumpAndSettle();
-
-      expect(find.text('Count: 1'), findsOneWidget);
-
-      counter.value = 2;
-      await tester.pumpAndSettle();
-
-      expect(find.text('Count: 2'), findsOneWidget);
-    },
-  );
 }
 
 class _CollisionWidget extends StatefulWidget {


### PR DESCRIPTION
## Description
Ensure that subscriptions with `startNow=false` do not invoke the callback immediately. This change addresses a bug where the callback was incorrectly triggered on initial subscription on derived beacons when they were already initialized. Tests confirm the expected behavior for both derived and lazy beacons.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore

