### PR TITLE
Add BeaconGroup.textEditing

### DIFF
--- a/examples/flutter_main/pubspec.lock
+++ b/examples/flutter_main/pubspec.lock
@@ -390,7 +390,7 @@ packages:
       path: "../../packages/state_beacon"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   state_beacon_core:
     dependency: "direct overridden"
     description:
@@ -404,7 +404,7 @@ packages:
       path: "../../packages/state_beacon_flutter"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   state_beacon_lint:
     dependency: "direct dev"
     description:

--- a/examples/shopping_cart/pubspec.lock
+++ b/examples/shopping_cart/pubspec.lock
@@ -211,21 +211,21 @@ packages:
       path: "../../packages/state_beacon"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   state_beacon_core:
     dependency: "direct overridden"
     description:
       path: "../../packages/state_beacon_core"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   state_beacon_flutter:
     dependency: "direct overridden"
     description:
       path: "../../packages/state_beacon_flutter"
       relative: true
     source: path
-    version: "2.0.0"
+    version: "2.0.1"
   stream_channel:
     dependency: transitive
     description:

--- a/packages/state_beacon_flutter/lib/src/extensions/beacon_group.dart
+++ b/packages/state_beacon_flutter/lib/src/extensions/beacon_group.dart
@@ -1,0 +1,20 @@
+import 'package:state_beacon_core/state_beacon_core.dart';
+import 'package:state_beacon_flutter/src/notifier/text_editing_controller.dart';
+
+/// Flutter extensions on BeaconGroup
+extension FlutterBeaconGroupx on BeaconGroup {
+  /// A beacon that wraps a `TextEditingController`. All changes to the
+  /// controller are reflected in the beacon and vice versa.
+  /// ```dart
+  /// final beacon = TextEditingBeacon();
+  /// final controller = beacon.controller;
+  ///
+  /// controller.text = 'Hello World';
+  ///
+  /// expect(beacon.value.text.'Hello World');
+  ///
+  /// ```
+  TextEditingBeacon textEditing({String? text, String? name}) {
+    return TextEditingBeacon(text: text, name: name, group: this);
+  }
+}

--- a/packages/state_beacon_flutter/lib/state_beacon_flutter.dart
+++ b/packages/state_beacon_flutter/lib/state_beacon_flutter.dart
@@ -2,7 +2,9 @@
 library;
 
 export 'package:state_beacon_core/state_beacon_core.dart' hide BeaconScheduler;
+
 export 'src/controller/controller.dart';
+export 'src/extensions/beacon_group.dart';
 export 'src/extensions/extensions.dart' hide hasNotifier;
 export 'src/notifier/text_editing_controller.dart';
 export 'src/scheduler.dart';

--- a/packages/state_beacon_flutter/test/src/notifier/text_editing_controller_test.dart
+++ b/packages/state_beacon_flutter/test/src/notifier/text_editing_controller_test.dart
@@ -58,7 +58,7 @@ void main() {
 
   test('should add beacon to group provided', () {
     final group = BeaconGroup();
-    final beacon = TextEditingBeacon(text: '1', group: group);
+    final beacon = group.textEditing(text: '1');
 
     expect(group.beacons.length, 1);
     expect(group.beacons.first, beacon);


### PR DESCRIPTION
## Description

This allows you to creating text editing beacon tied to a group in a simpler manner.

### old:
```dart
final usernameField = TextEditingBeacon(text:'', group:B)
```
### new:
```dart
final usernameField =  B.textEditing(text:'')
```

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [ ] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
