### PR TITLE
V3

### DIFF
--- a/packages/state_beacon/CHANGELOG.md
+++ b/packages/state_beacon/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.0
+
+- [Breaking] `anyBeacon.next()` now throws if the beacon is disposed while waiting for the next value. This is a breaking change because previously it would complete with the current value if the beacon was disposed.
+
+- [Feat] Add `anyBeacon.nextOrNull()` method that returns `null` if the beacon is disposed while waiting for the next value.
+
 # 2.0.4
 
 - [chore] Update repo links

--- a/packages/state_beacon_core/CHANGELOG.md
+++ b/packages/state_beacon_core/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 3.0.0
+
+- [Breaking] `anyBeacon.next()` now throws if the beacon is disposed while waiting for the next value. This is a breaking change because previously it would complete with the current value if the beacon was disposed.
+
+- [Feat] Add `anyBeacon.nextOrNull()` method that returns `null` if the beacon is disposed while waiting for the next value.
+
+
 # 2.0.3
 
 - [chore] Update repo links

--- a/packages/state_beacon_core/lib/src/extensions/readable.dart
+++ b/packages/state_beacon_core/lib/src/extensions/readable.dart
@@ -53,10 +53,8 @@ extension ReadableBeaconUtils<T> on ReadableBeacon<T> {
     final rmCallback = onDispose(() {
       if (completer.isCompleted) return;
 
-      final newValue = isEmpty ? fallback : peek();
-
-      if (newValue != null) {
-        completer.complete(newValue);
+      if (fallback != null || null is T) {
+        completer.complete(fallback);
       } else {
         completer.completeError(
           Exception(
@@ -74,6 +72,41 @@ extension ReadableBeaconUtils<T> on ReadableBeacon<T> {
     rmCallback(); // allow the completer to be garbage collected
 
     return result;
+  }
+
+  /// Listens for the next value emitted by this Beacon and returns it as a Future.
+  ///
+  /// This method subscribes to this Beacon and waits for the next value
+  /// that matches the optional [filter] function. If [filter] is provided and
+  /// returns `false` for a emitted value, the method continues waiting for the
+  /// next value that matches the filter. If no [filter] is provided,
+  /// the method completes with the first value received.
+  ///
+  /// If this is a lazy beacon and it's disposed before a value is emitted,
+  /// the future will be completed with `null`.
+  ///
+  /// Example:
+  ///
+  /// ```dart
+  /// final age = Beacon.writable(20);
+  ///
+  /// Timer(Duration(seconds: 1), () => age.value = 21;);
+  ///
+  /// final nextAge = await age.nextOrNull(); // returns 21 after 1 second
+  /// ```
+  ///
+  /// Parameters:
+  ///   - [filter]: An optional function that determines whether a value is accepted.
+  ///
+  /// Returns a Future that completes with the next emitted value or `null` if the beacon is disposed.
+  Future<T?> nextOrNull({
+    bool Function(T)? filter,
+  }) async {
+    try {
+      return await next(filter: filter);
+    } catch (e) {
+      return null;
+    }
   }
 }
 

--- a/packages/state_beacon_flutter/CHANGELOG.md
+++ b/packages/state_beacon_flutter/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 3.0.0
+
+- [Breaking] `anyBeacon.next()` now throws if the beacon is disposed while waiting for the next value. This is a breaking change because previously it would complete with the current value if the beacon was disposed.
+
+- [Feat] Add `anyBeacon.nextOrNull()` method that returns `null` if the beacon is disposed while waiting for the next value.
+
 # 2.0.4
 
 - [chore] Update repo links


### PR DESCRIPTION
- [Breaking] `anyBeacon.next()` now throws if the beacon is disposed while waiting for the next value. This is a breaking change because previously it would complete with the current value if the beacon was disposed.

- [Feat] Add `anyBeacon.nextOrNull()` method that returns `null` if the beacon is disposed while waiting for the next value.
