### PR TITLE
add asError getter to the AsyncValue base class and its AsyncError subsclass

### DIFF
--- a/packages/state_beacon_core/lib/src/common/async_value.dart
+++ b/packages/state_beacon_core/lib/src/common/async_value.dart
@@ -51,6 +51,10 @@ sealed class AsyncValue<T> {
   /// Returns `true` if this is [AsyncError].
   bool get isError => false;
 
+  /// Returns the [AsyncError] if this is [AsyncError].
+  /// Otherwise returns `null`.
+  AsyncError<T>? get asError => null;
+
   /// Executes the future provided and returns [AsyncData] with the result
   /// if successful or [AsyncError] if an exception is thrown.
   ///
@@ -159,6 +163,9 @@ class AsyncError<T> extends AsyncValue<T> {
 
   @override
   bool get isError => true;
+
+  @override
+  AsyncError<T> get asError => this;
 
   @override
   bool operator ==(Object other) =>

--- a/packages/state_beacon_core/test/src/common/async_value_test.dart
+++ b/packages/state_beacon_core/test/src/common/async_value_test.dart
@@ -103,6 +103,20 @@ void main() {
     expect(errorResult, isA<AsyncError>());
   });
 
+  test('should return correct values for asError', () {
+    final loading = AsyncLoading();
+    expect(loading.asError, null);
+
+    final idle = AsyncIdle();
+    expect(idle.asError, null);
+
+    final error = AsyncError('error', StackTrace.current);
+    expect(error.asError, error);
+
+    final data = AsyncData(1);
+    expect(data.asError, null);
+  });
+
   test('should share the same hashCode with sister instances', () {
     final data = AsyncData(1);
     final data2 = AsyncData(1);


### PR DESCRIPTION
## Description

This allows users to easily retrieve the AsyncError instance when the state is an error, or null otherwise.

## Type of Change

<!--- Put an `x` in all the boxes that apply: -->

-   [x] ✨ New feature (non-breaking change which adds functionality)
-   [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
-   [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
-   [ ] 🧹 Code refactor
-   [ ] ✅ Build configuration change
-   [ ] 📝 Documentation
-   [ ] 🗑️ Chore
